### PR TITLE
Issue #12: Implementacja endpointu rejestracji, Issue #13: Dodanie hashowania haseł.

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/medicalyticsss.iml" filepath="$PROJECT_DIR$/.idea/medicalyticsss.iml" />
-    </modules>
-  </component>
-</project>

--- a/backend/api-tests/test_login.http
+++ b/backend/api-tests/test_login.http
@@ -1,2 +1,0 @@
-### Test logowania laboratorium
-POST http://localhost:8080/api/auth/login?username=lab_olsztyn_01&password=lab2026

--- a/backend/api-tests/test_logowania.http
+++ b/backend/api-tests/test_logowania.http
@@ -1,0 +1,5 @@
+### Test logowania (Poprawne dane)
+POST http://localhost:8080/api/auth/login?username=lab_olsztyn&password=SuperTajneHaslo123
+
+### Test logowania (BŁĘDNE HASŁO)
+POST http://localhost:8080/api/auth/login?username=lab_olsztyn&password=zle_haslo_123

--- a/backend/api-tests/test_rejestracji.http
+++ b/backend/api-tests/test_rejestracji.http
@@ -1,0 +1,2 @@
+### Rejestracja nowego użytkownika
+POST http://localhost:8080/api/auth/register?username=lab_olsztyn&password=SuperTajneHaslo123

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,6 +56,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/medicalyticsss/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.medicalyticsss.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.Customizer;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // Wyłącza ochronę CSRF, żeby pozwolić na POST z testów HTTP
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // NA RAZIE!!! pozwalamy każdemu na wszystko
+                );
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/medicalyticsss/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.medicalyticsss.backend.model.User;
 import com.medicalyticsss.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
@@ -16,22 +17,43 @@ public class AuthController {
     @Autowired // Znajduje gotowy obiekt UserRepository
     private UserRepository userRepository;
 
-    @PostMapping("/login") // Metoda uruchomi się gdy ktoś wyśle żądanie POST na /api/auth/login.
+    @Autowired
+    private PasswordEncoder passwordEncoder; // Z klasy SecurityConfig
 
-    public ResponseEntity<String> login(@RequestParam String username, @RequestParam String password) {
+    @PostMapping("/register") // Metoda uruchomi się gdy ktoś wyśle żądanie POST na /api/auth/register.
+    public String register(@RequestParam String username, @RequestParam String password) {
 
-        // 1. Szuka użytkownika po zmiennej username
-        Optional<User> userOptional = userRepository.findByUsername(username);
-
-        if (userOptional.isPresent()) {
-            User user = userOptional.get();
-
-            // 2. Sprawdza hasło po zmiennej password
-            if (user.getPasswordHash().equals(password)) {
-                return ResponseEntity.ok("Zalogowano pomyślnie!");
-            }
+        // 1. Sprawdza, czy nazwa użytkownika nie jest już zajęta
+        if (userRepository.findByUsername(username).isPresent()) {
+            return "Błąd: Użytkownik o takiej nazwie już istnieje!";
         }
 
-        return ResponseEntity.status(401).body("Błędny login lub hasło");
+        // 2. Hashuje hasło
+        String encodedPassword = passwordEncoder.encode(password);
+
+        // 3. Tworzy i zapisuje użytkownika
+        User newUser = new User();
+        newUser.setUsername(username);
+        newUser.setPasswordHash(encodedPassword);
+        userRepository.save(newUser);
+
+        return "Zarejestrowano pomyślnie!";
+    }
+
+    @PostMapping("/login") // Metoda uruchomi się gdy ktoś wyśle żądanie POST na /api/auth/login.
+    public String login(@RequestParam String username, @RequestParam String password) {
+
+        // 1. Zwraca użytkownika o podanym loginie
+        return userRepository.findByUsername(username)
+
+                // 2. Jeżeli użytkownik znaleziony, to sprawdza hasło
+                .map(user -> {
+                    if (passwordEncoder.matches(password, user.getPasswordHash())) {
+                        return "Zalogowano pomyślnie!";
+                    } else {
+                        return "Błędne login lub hasło!";
+                    }
+                })
+                .orElse("Nie znaleziono użytkownika!");
     }
 }


### PR DESCRIPTION
- Issue #12: Implementacja endpointu rejestracji.
- Issue #13: Dodanie hashowania haseł.

Zmiany:
1. Dodano zależność spring-boot-starter-security w pom.xml.
2. Stworzono SecurityConfig z PasswordEncoder oraz filtrem dostępu (permitAll) tymczasowo !!!.
3. Rozbudowano AuthController o logikę rejestracji i bezpiecznego logowania (matches()).
4. Dodano nowe skrypty testowe .http do folderu api-tests.

Instrukcja testowania:
Zadania można przetestować w folderze `api-tests`:

1. **Rejestracja (#12 & #13):**
   - Uruchom request `POST /register` z parametrami `username` i `password` (można sobie zmienić w pliku).
   - **Oczekiwany wynik:** Status 200 OK i komunikat "Zarejestrowano pomyślnie!".
   - **Baza danych:** W kolumnie `password_hash` powinien pojawić sie hash.

2. **Logowanie - Poprawne dane:**
   - Uruchom request `POST /login` z tymi samymi danymi co przy rejestracji (zmień w pliku jak coś).
   - **Oczekiwany wynik:** "Zalogowano pomyślnie!".

3. **Logowanie - Błędne hasło:**
   - Uruchom request `POST /login` ze złym hasłem.
   - **Oczekiwany wynik:** "Błędne login lub hasło!".
   - 
Closes #12
Closes #13