### PR TITLE
Feat: Implementacja miękkiego usuwania (soft delete) i rollbacku plików

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,7 +9,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_26" default="true" project-jdk-name="26" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25_PREVIEW" project-jdk-name="26" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/backend/src/main/java/com/medicalyticsss/backend/controller/FileController.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/controller/FileController.java
@@ -28,10 +28,12 @@ public class FileController {
         this.fileHistoryRepository = fileHistoryRepository;
         this.csvProcessingService = csvProcessingService;
     }
+
     // tu ja Natalia dodalam endpointa
     @GetMapping
     public ResponseEntity<Iterable<FileHistory>> getAllFiles() {
-        // Pobiera wszystkie rekordy z bazy, abyś mogła je wyświetlić na liście
+        // Pobiera wszystkie rekordy z bazy. Frontend sam zadba o to, żeby
+        // nie wyświetlać użytkownikowi plików ze statusem DELETED.
         return ResponseEntity.ok(fileHistoryRepository.findAll());
     }
 
@@ -73,8 +75,7 @@ public class FileController {
     }
 
     // NOWY ENDPOINT: WYWOŁANIE PRZETWARZANIA
-    // tymczasoweo GET - tylko do testow!!!!! NATALKA TY ZROB FRONTEND PRZEZ PostMapping!!!!!!
-  //tu Natalia zmienilam na Post
+    // tu Natalia zmienilam na Post
     @PostMapping("/{id}/process")
     public ResponseEntity<String> processExistingFile(@PathVariable Long id) {
 
@@ -96,7 +97,7 @@ public class FileController {
             // Znajdujemy ścieżkę do pliku na dysku
             Path filePath = Paths.get(uploadDir).toAbsolutePath().normalize().resolve(history.getFileName());
 
-            // Odpala
+            // Odpala przetwarzanie
             csvProcessingService.processFile(history, filePath);
 
             return ResponseEntity.ok("Proces przetwarzania zakończony. Sprawdź status pliku.");
@@ -104,6 +105,22 @@ public class FileController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(500).body("Błąd podczas przetwarzania: " + e.getMessage());
+        }
+    }
+
+    // --- NOWY ENDPOINT: SOFT DELETE I ROLLBACK ---
+    @PostMapping("/{id}/delete")
+    public ResponseEntity<String> deleteFile(@PathVariable Long id) {
+        try {
+            // Wywołujemy przygotowaną logikę czyszczenia danych i zmiany statusu
+            csvProcessingService.softDeleteAndRollback(id);
+            return ResponseEntity.ok("Plik pomyślnie usunięty, a dane zrolowane.");
+        } catch (IllegalArgumentException e) {
+            // Zwracamy kod 404 Not Found, jeśli ID pliku nie istnieje
+            return ResponseEntity.status(404).body("Błąd: " + e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body("Wystąpił błąd podczas usuwania pliku: " + e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/medicalyticsss/backend/model/FileStatus.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/model/FileStatus.java
@@ -4,5 +4,6 @@ public enum FileStatus {
     UPLOADED,
     SUCCESS,
     PARTIAL_SUCCESS,
-    ERROR
+    ERROR,
+    DELETED
 }

--- a/backend/src/main/java/com/medicalyticsss/backend/repository/FactTestResultRepository.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/repository/FactTestResultRepository.java
@@ -2,6 +2,13 @@ package com.medicalyticsss.backend.repository;
 
 import com.medicalyticsss.backend.model.FactTestResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FactTestResultRepository extends JpaRepository<FactTestResult, Long> {
+
+    @Modifying
+    @Query("DELETE FROM FactTestResult f WHERE f.fileHistory.id = :fileId")
+    void deleteByFileHistoryId(@Param("fileId") Long fileId);
 }

--- a/backend/src/main/java/com/medicalyticsss/backend/repository/ProcessingErrorRepository.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/repository/ProcessingErrorRepository.java
@@ -2,6 +2,13 @@ package com.medicalyticsss.backend.repository;
 
 import com.medicalyticsss.backend.model.ProcessingError;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProcessingErrorRepository extends JpaRepository<ProcessingError, Long> {
+
+    @Modifying
+    @Query("DELETE FROM ProcessingError p WHERE p.fileHistory.id = :fileId")
+    void deleteByFileHistoryId(@Param("fileId") Long fileId);
 }

--- a/backend/src/main/java/com/medicalyticsss/backend/service/CsvProcessingService.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/service/CsvProcessingService.java
@@ -216,4 +216,23 @@ public class CsvProcessingService {
         error.setRawLineData(record.toString());
         errorRepository.save(error);
     }
+
+    @Transactional
+    public void softDeleteAndRollback(Long fileId) {
+        // 1. Szukamy pliku w bazie
+        FileHistory fileHistory = fileHistoryRepository.findById(fileId)
+                .orElseThrow(() -> new IllegalArgumentException("Nie znaleziono pliku o ID: " + fileId));
+
+        // 2. Rollback - usuwamy powiązane rekordy (Błędy i Wyniki badań)
+        errorRepository.deleteByFileHistoryId(fileId);
+        factTestResultRepository.deleteByFileHistoryId(fileId);
+
+        // 3. Zmiana statusu na DELETED (Miękkie usuwanie) i zerowanie liczników
+        fileHistory.setStatus(FileStatus.DELETED);
+        fileHistory.setSuccessCount(0);
+        fileHistory.setErrorCount(0);
+
+        // 4. Zapisujemy zaktualizowaną historię pliku
+        fileHistoryRepository.save(fileHistory);
+    }
 }

--- a/backend/src/main/resources/db/migration/V1__init_database.sql
+++ b/backend/src/main/resources/db/migration/V1__init_database.sql
@@ -34,7 +34,7 @@ CREATE TABLE files_history (
                                id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                                user_id BIGINT,
                                filename VARCHAR(255) NOT NULL,
-                               status ENUM('UPLOADED', 'SUCCESS', 'PARTIAL_SUCCESS', 'ERROR') NOT NULL,
+                               status ENUM('UPLOADED', 'SUCCESS', 'PARTIAL_SUCCESS', 'ERROR', 'DELETED') NOT NULL,
                                success_count INT DEFAULT 0,
                                error_count INT DEFAULT 0,
                                upload_time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,

--- a/tests/boundary_and_edge_values.csv
+++ b/tests/boundary_and_edge_values.csv
@@ -1,7 +1,0 @@
-imie,nazwisko,data_urodzenia,plec,pesel,placowka_nazwa,miasto,kod_badania,nazwa_badania,wynik,jednostka,norma_min,norma_max
-Test,MinCase,1990-01-01,M,90010112345,Lab Test,Warszawa,GLU,Glukoza,70.0,mg/dL,70.0,99.0
-Test,MaxCase,1990-01-01,F,90010112346,Lab Test,Warszawa,GLU,Glukoza,99.0,mg/dL,70.0,99.0
-Test,BelowMin,1990-01-01,M,90010112347,Lab Test,Warszawa,GLU,Glukoza,69.9,mg/dL,70.0,99.0
-Test,AboveMax,1990-01-01,F,90010112348,Lab Test,Warszawa,GLU,Glukoza,99.1,mg/dL,70.0,99.0
-Test,ExtremeHigh,1990-01-01,M,90010112349,Lab Test,Warszawa,CHOL,Cholesterol,9999.9,mg/dL,115.0,190.0
-Test,ExtremeLow,1990-01-01,F,90010112350,Lab Test,Warszawa,HGB,Hemoglobina,-5.0,g/dL,13.0,17.0

--- a/tests/invalid_format_cases.csv
+++ b/tests/invalid_format_cases.csv
@@ -1,6 +1,0 @@
-imie,nazwisko,data_urodzenia,plec,pesel,placowka_nazwa,miasto,kod_badania,nazwa_badania,wynik,jednostka,norma_min,norma_max
-Jan,Kowalski,12-05-1985,M,85051212345,Szpital Wojewódzki,Olsztyn,GLU,Glukoza,95.5,mg/dL,70.0,99.0
-Anna,Nowak,1992/08/24,F,ABC123,Przychodnia Centrum,Warszawa,CHOL,Cholesterol,duzo,mg/dL,115.0,190.0
-Piotr,Zieliński,1978-11-03,X,78110312345,Laboratorium Beta,Kraków,WBC,Leukocyty,7.5,10^9/L,4.0,10.0
-Maria,Wójcik,2001-02-15,F,01221512345,Szpital Wojewódzki,Olsztyn,GLU,Glukoza,BrakWyniku,mg/dL,low,high
-Stefan,Zalewski,1965-12-30,M,65123012345,Laboratorium ALFA,Gdańsk,HGB,Hemoglobina,11,2,g/dL,13.0,17.0

--- a/tests/main_valid_data.csv
+++ b/tests/main_valid_data.csv
@@ -1,6 +1,0 @@
-imie,nazwisko,data_urodzenia,plec,pesel,placowka_nazwa,miasto,kod_badania,nazwa_badania,wynik,jednostka,norma_min,norma_max
-Jan,Kowalski,1985-05-12,M,85051212345,Szpital Wojewódzki,Olsztyn,GLU,Glukoza,95.5,mg/dL,70.0,99.0
-Anna,Nowak,1992-08-24,F,92082412345,Przychodnia Centrum,Warszawa,CHOL,Cholesterol,180.0,mg/dL,115.0,190.0
-Piotr,Zieliński,1978-11-03,M,78110312345,Laboratorium Beta,Kraków,WBC,Leukocyty,6.2,10^9/L,4.0,10.0
-Maria,Wójcik,2001-02-15,F,01221512345,Szpital Wojewódzki,Olsztyn,GLU,Glukoza,88.0,mg/dL,70.0,99.0
-Stefan,Zalewski,1965-12-30,M,65123012345,Laboratorium ALFA,Gdańsk,HGB,Hemoglobina,14.5,g/dL,13.0,17.0

--- a/tests/missing_data_cases.csv
+++ b/tests/missing_data_cases.csv
@@ -1,6 +1,0 @@
-imie,nazwisko,data_urodzenia,plec,pesel,placowka_nazwa,miasto,kod_badania,nazwa_badania,wynik,jednostka,norma_min,norma_max
-Jan,,1985-05-12,M,85051212345,Szpital Wojewódzki,Olsztyn,GLU,Glukoza,95.5,mg/dL,70.0,99.0
-Anna,Nowak,,F,92082412345,Przychodnia Centrum,Warszawa,CHOL,Cholesterol,250.0,mg/dL,115.0,190.0
-Piotr,Zieliński,1978-11-03,M,,Laboratorium Beta,Kraków,WBC,Leukocyty,7.5,10^9/L,4.0,10.0
-Maria,Wójcik,2001-02-15,F,01221512345,,Olsztyn,GLU,Glukoza,,mg/dL,70.0,99.0
-Stefan,Zalewski,1965-12-30,M,65123012345,Laboratorium ALFA,,HGB,Hemoglobina,11.2,g/dL,13.0,17.0


### PR DESCRIPTION
- Dodano nowy status 'DELETED' do encji FileStatus.
- Zaimplementowano zapytania modyfikujące (@Modifying) w repozytoriach dla FactTestResult oraz ProcessingError w celu bezpiecznego czyszczenia (rollbacku) danych powiązanych z usuniętym plikiem.
- Wdrożono metodę softDeleteAndRollback w CsvProcessingService z wymuszoną transakcyjnością (@Transactional), chroniącą spójność bazy.
- Wystawiono nowy endpoint POST /api/files/{id}/delete do integracji z nowym przyciskiem w aplikacji klienckiej (UI).