### PR TITLE
feat: Wyświetlanie szczegółów błędu przetwarzania pliku (Closes #67)

### DIFF
--- a/backend/src/main/java/com/medicalyticsss/backend/controller/FileController.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/controller/FileController.java
@@ -2,7 +2,9 @@ package com.medicalyticsss.backend.controller;
 
 import com.medicalyticsss.backend.model.FileHistory;
 import com.medicalyticsss.backend.model.FileStatus;
+import com.medicalyticsss.backend.model.ProcessingError;
 import com.medicalyticsss.backend.repository.FileHistoryRepository;
+import com.medicalyticsss.backend.repository.ProcessingErrorRepository;
 import com.medicalyticsss.backend.service.CsvProcessingService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -23,10 +25,12 @@ public class FileController {
 
     private final FileHistoryRepository fileHistoryRepository;
     private final CsvProcessingService csvProcessingService;
+    private final ProcessingErrorRepository processingErrorRepository;
 
-    public FileController(FileHistoryRepository fileHistoryRepository, CsvProcessingService csvProcessingService) {
+    public FileController(FileHistoryRepository fileHistoryRepository, CsvProcessingService csvProcessingService, ProcessingErrorRepository processingErrorRepository) {
         this.fileHistoryRepository = fileHistoryRepository;
         this.csvProcessingService = csvProcessingService;
+        this.processingErrorRepository = processingErrorRepository;
     }
 
     // tu ja Natalia dodalam endpointa
@@ -168,5 +172,13 @@ public class FileController {
             e.printStackTrace();
             return ResponseEntity.status(500).body("Błąd podczas odczytu pliku: " + e.getMessage());
         }
+    }
+    @GetMapping("/{id}/errors")
+    public ResponseEntity<java.util.List<ProcessingError>> getFileErrors(@PathVariable Long id) {
+        if (!fileHistoryRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        java.util.List<ProcessingError> errors = processingErrorRepository.findByFileHistoryId(id);
+        return ResponseEntity.ok(errors);
     }
 }

--- a/backend/src/main/java/com/medicalyticsss/backend/repository/ProcessingErrorRepository.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/repository/ProcessingErrorRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface ProcessingErrorRepository extends JpaRepository<ProcessingError, Long> {
 
     @Modifying
     @Query("DELETE FROM ProcessingError p WHERE p.fileHistory.id = :fileId")
     void deleteByFileHistoryId(@Param("fileId") Long fileId);
+    List<ProcessingError> findByFileHistoryId(Long fileHistoryId);
 }

--- a/frontend/src/main/java/com/example/frontend/models/FileItem.java
+++ b/frontend/src/main/java/com/example/frontend/models/FileItem.java
@@ -5,6 +5,9 @@ public class FileItem {
     public String fileName;
     public String status;
     public String uploadTime;
+    public String content;
+
+    public ProcessingError processingError;
 
     // Nadpisujemy metodę toString, aby ListView na dashboardzie ładnie wyświetlało nazwy
     @Override

--- a/frontend/src/main/java/com/example/frontend/models/ProcessingError.java
+++ b/frontend/src/main/java/com/example/frontend/models/ProcessingError.java
@@ -1,0 +1,8 @@
+package com.example.frontend.models;
+
+public class ProcessingError {
+    public Long id;
+    public Integer errorRowNumber;
+    public String errorMessage;
+    public String rawLineData;
+}

--- a/frontend/src/main/java/com/example/frontend/services/FileService.java
+++ b/frontend/src/main/java/com/example/frontend/services/FileService.java
@@ -1,12 +1,16 @@
 package com.example.frontend.services;
 
 import com.example.frontend.models.FileItem;
+import com.example.frontend.models.ProcessingError;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Collections;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
 public class FileService {
@@ -91,5 +95,26 @@ public class FileService {
                 .build();
         return AuthService.getClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(res -> new com.google.gson.Gson().fromJson(res.body(), String[].class));
+    }
+
+    // Metoda do wyswietlania bledow
+    public static CompletableFuture<List<ProcessingError>> getFileErrors(Long fileId) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080/api/files/" + fileId + "/errors"))
+                .GET()
+                .build();
+
+        return AuthService.getClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Type listType = new TypeToken<ArrayList<ProcessingError>>(){}.getType();
+                        return gson.fromJson(response.body(), listType);
+                    }
+                    return Collections.<ProcessingError>emptyList();
+                })
+                .exceptionally(e -> {
+                    e.printStackTrace();
+                    return Collections.<ProcessingError>emptyList();
+                });
     }
 }

--- a/frontend/src/main/java/com/example/frontend/views/DashboardView.java
+++ b/frontend/src/main/java/com/example/frontend/views/DashboardView.java
@@ -26,7 +26,24 @@ public class DashboardView {
         TextArea previewArea = new TextArea();
         previewArea.setEditable(false);
         VBox.setVgrow(previewArea, Priority.ALWAYS);
-        previewPanel.getChildren().addAll(previewLabel, previewArea);
+
+        // 1. Pole na błędy (usuwamy stąd tło, dajemy tylko czcionkę)
+        Label errorDetailsLabel = new Label();
+        errorDetailsLabel.setWrapText(true);
+        errorDetailsLabel.setStyle("-fx-text-fill: #FF3333; -fx-font-family: 'Consolas';");
+
+        // 2. NOWE: Opakowujemy Label w ScrollPane (suwak)
+        ScrollPane errorScrollPane = new ScrollPane(errorDetailsLabel);
+        errorScrollPane.setFitToWidth(true); // Ważne: dzięki temu tekst w Labelu nadal będzie się zawijał
+        errorScrollPane.setMaxHeight(180);   // Blokujemy wysokość, żeby NIE spychał TextArea!
+        errorScrollPane.setStyle("-fx-background: #2A1A1A; -fx-background-color: #2A1A1A; -fx-padding: 10; -fx-background-radius: 5;");
+
+        // Ukrywamy cały suwak, a nie tylko Label
+        errorScrollPane.setVisible(false);
+        errorScrollPane.setManaged(false);
+
+        // Dodajemy errorScrollPane zamiast samego Labela
+        previewPanel.getChildren().addAll(previewLabel, previewArea, errorScrollPane);
         HBox.setHgrow(previewPanel, Priority.ALWAYS);
 
         // --- PANEL PRAWY (STEROWANIE) ---
@@ -104,12 +121,32 @@ public class DashboardView {
         processBtn.setOnAction(e -> {
             FileItem selected = fileListView.getSelectionModel().getSelectedItem();
             if (selected != null) {
-                FileService.processFile(selected.id).thenAccept(res -> Platform.runLater(() -> {
+                // Zapamiętujemy ID przetwarzanego pliku, zanim lista się odświeży
+                Long processedFileId = selected.id;
+
+                FileService.processFile(processedFileId).thenAccept(res -> Platform.runLater(() -> {
                     Alert alert = new Alert(Alert.AlertType.INFORMATION);
                     alert.setContentText(res);
                     alert.showAndWait();
-                    // Odśwież listę po przetworzeniu
-                    refreshBtn.fire();
+
+                    // Odświeżamy listę ręcznie, żeby po zakończeniu wywołać podgląd
+                    FileService.fetchFiles().thenAccept(files -> Platform.runLater(() -> {
+                        // Wrzucamy nowe pliki na listę
+                        fileListView.getItems().setAll(files);
+                        fileStatusLabel.setText("Zaktualizowano listę po przetwarzaniu.");
+
+                        // Szukamy naszego przetworzonego pliku na nowej liście
+                        for (FileItem item : files) {
+                            if (item.id.equals(processedFileId)) {
+                                // Zaznaczamy go ponownie na liście (żeby podświetlił się na niebiesko)
+                                fileListView.getSelectionModel().select(item);
+
+                                // Automatycznie "klikamy" przycisk podglądu!
+                                previewBtn.fire();
+                                break;
+                            }
+                        }
+                    }));
                 }));
             }
         });
@@ -121,6 +158,10 @@ public class DashboardView {
                 FileService.deleteFile(selected.id).thenAccept(res -> Platform.runLater(() -> {
                     fileStatusLabel.setText(res);
                     previewArea.clear();
+                    // NOWE: Ukrywamy i czyścimy panel z błędami po usunięciu pliku
+                    errorDetailsLabel.setVisible(false);
+                    errorDetailsLabel.setManaged(false);
+                    errorDetailsLabel.setText("");
                     refreshBtn.fire();
                 }));
             }
@@ -130,9 +171,46 @@ public class DashboardView {
         previewBtn.setOnAction(e -> {
             FileItem selected = fileListView.getSelectionModel().getSelectedItem();
             if (selected != null) {
+
+                // 1. Pobieranie normalnego podglądu tekstu
                 FileService.getFilePreview(selected.id).thenAccept(lines -> Platform.runLater(() -> {
                     previewArea.setText(String.join("\n", lines));
                 }));
+
+// 2. NOWE: Pobieranie błędów, jeśli plik ma status ERROR lub PARTIAL_SUCCESS
+                if ("ERROR".equals(selected.status) || "PARTIAL_SUCCESS".equals(selected.status)) {
+                    FileService.getFileErrors(selected.id).thenAccept(errors -> {
+                        Platform.runLater(() -> {
+                            if (errors != null && !errors.isEmpty()) {
+                                StringBuilder errorText = new StringBuilder();
+                                errorText.append("⚠️ Znaleziono błędy:\n\n");
+
+                                for (var error : errors) {
+                                    errorText.append("🔴 ");
+                                    if (error.errorRowNumber != null) {
+                                        errorText.append("[Wiersz ").append(error.errorRowNumber).append("] ");
+                                    }
+                                    errorText.append(error.errorMessage != null ? error.errorMessage : "Nieznany błąd");
+                                    if (error.rawLineData != null && !error.rawLineData.isBlank()) {
+                                        errorText.append("\n    └─ Błędne dane: ").append(error.rawLineData);
+                                    }
+                                    errorText.append("\n");
+                                }
+                                errorDetailsLabel.setText(errorText.toString());
+                            } else {
+                                errorDetailsLabel.setText("⚠️ Plik ma status ERROR, ale w bazie nie ma szczegółów.");
+                            }
+                            // TUTAJ: Pokazujemy cały przewijany panel, a nie tylko napis
+                            errorScrollPane.setVisible(true);
+                            errorScrollPane.setManaged(true);
+                        });
+                    });
+                } else {
+                    // TUTAJ: Ukrywamy cały przewijany panel, jeśli plik jest czysty
+                    errorScrollPane.setVisible(false);
+                    errorScrollPane.setManaged(false);
+                    errorDetailsLabel.setText("");
+                }
             }
         });
 


### PR DESCRIPTION
Implementacja pełnej obsługi wyświetlania szczegółów błędów walidacji i przetwarzania plików CSV (Full-Stack). Zmiany pozwalają użytkownikowi natychmiast zobaczyć, które wiersze i z jakiego powodu zostały odrzucone przez system.

Zamyka: #67

### Backend
- Rozszerzono `ProcessingErrorRepository` o metodę wyszukującą błędy po ID pliku (`findByFileHistoryId`).
- Dodano nowy endpoint w `FileController`: `GET /api/files/{id}/errors`, który zwraca listę błędów w formacie JSON.

### Frontend (JavaFX)
- Dodano asynchroniczną metodę `getFileErrors` w `FileService`, zintegrowaną z `AuthService` (zapytania nie blokują wątku UI).
- Rozbudowano `DashboardView` o sekcję błędów osadzoną w `ScrollPane` z limitem wysokości, dzięki czemu interfejs zachowuje właściwe proporcje przy dużej liczbie komunikatów.
- Zaimplementowano automatyczne dociąganie i pokazywanie błędów po kliknięciu "Podgląd" dla plików ze statusami `ERROR` oraz `PARTIAL_SUCCESS`.
- Usprawniono UX: po zakończeniu akcji "Przetwórz", lista odświeża się automatycznie, plik jest ponownie zaznaczany i od razu wywoływany jest podgląd wraz z błędami.
- Zapewniono czyszczenie i ukrywanie panelu błędów w momencie usunięcia pliku z systemu.

## Jak przetestować?
1. Uruchom backend i aplikację kliencką.
2. Wgraj plik o niepoprawnej strukturze (np. inny plik CSV) lub taki, który wygeneruje częściowy sukces (`PARTIAL_SUCCESS`).
3. Kliknij "Przetwórz" – po zamknięciu okna informacyjnego podgląd i błędy powinny załadować się automatycznie.
4. Sprawdź, czy okienko z błędami na dole lewego panelu posiada suwak (scroll) i poprawnie zawija długie linie tekstu.
5. Usuń plik i upewnij się, że pole z błędami zniknęło z widoku.