### PR TITLE
Externalize test type dictionary

### DIFF
--- a/backend/src/main/java/com/medicalyticsss/backend/dto/TestTypeDictionaryEntry.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/dto/TestTypeDictionaryEntry.java
@@ -1,0 +1,61 @@
+package com.medicalyticsss.backend.dto;
+
+import java.math.BigDecimal;
+
+public class TestTypeDictionaryEntry {
+
+    private String testCode;
+    private String testName;
+    private String categoryName;
+    private String unit;
+    private BigDecimal normMin;
+    private BigDecimal normMax;
+
+    public String getTestCode() {
+        return testCode;
+    }
+
+    public void setTestCode(String testCode) {
+        this.testCode = testCode;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public BigDecimal getNormMin() {
+        return normMin;
+    }
+
+    public void setNormMin(BigDecimal normMin) {
+        this.normMin = normMin;
+    }
+
+    public BigDecimal getNormMax() {
+        return normMax;
+    }
+
+    public void setNormMax(BigDecimal normMax) {
+        this.normMax = normMax;
+    }
+}

--- a/backend/src/main/java/com/medicalyticsss/backend/seeder/DictionarySeeder.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/seeder/DictionarySeeder.java
@@ -1,168 +1,44 @@
 package com.medicalyticsss.backend.seeder;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.medicalyticsss.backend.dto.TestTypeDictionaryEntry;
 import com.medicalyticsss.backend.model.TestType;
 import com.medicalyticsss.backend.repository.TestTypeRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 public class DictionarySeeder implements CommandLineRunner {
 
     private final TestTypeRepository testTypeRepository;
+    private final ObjectMapper objectMapper;
+    private final ResourceLoader resourceLoader;
 
-    public DictionarySeeder(TestTypeRepository testTypeRepository) {
+    @Value("${dictionary.tests.path:classpath:dictionaries/test-types.json}")
+    private String dictionaryPath;
+
+    public DictionarySeeder(TestTypeRepository testTypeRepository, ObjectMapper objectMapper, ResourceLoader resourceLoader) {
         this.testTypeRepository = testTypeRepository;
+        this.objectMapper = objectMapper;
+        this.resourceLoader = resourceLoader;
     }
 
     @Override
-    public void run(String... args) {
-        // Twardy słownik badań
-        List<TestType> authoritativeTests = List.of(
-                // --- MORFOLOGIA KRWI ---
-                createTest("WBC", "Leukocyty", "Morfologia", "10^9/L", "4.0", "10.0"),
-                createTest("RBC", "Erytrocyty", "Morfologia", "10^12/L", "4.2", "5.4"),
-                createTest("HGB", "Hemoglobina", "Morfologia", "g/dL", "12.0", "16.0"),
-                createTest("HCT", "Hematokryt", "Morfologia", "%", "37.0", "47.0"),
-                createTest("MCV", "Średnia objętość krwinki (MCV)", "Morfologia", "fL", "80.0", "100.0"),
-                createTest("MCH", "Średnia masa Hb w krwince (MCH)", "Morfologia", "pg", "27.0", "32.0"),
-                createTest("MCHC", "Średnie stężenie Hb (MCHC)", "Morfologia", "g/dL", "32.0", "36.0"),
-                createTest("PLT", "Płytki krwi", "Morfologia", "10^9/L", "150.0", "400.0"),
-                createTest("RDW", "Rozkład objętości erytrocytów", "Morfologia", "%", "11.5", "14.5"),
-                createTest("NEUT", "Neutrofile", "Morfologia", "10^9/L", "2.0", "7.0"),
-                createTest("LYMPH", "Limfocyty", "Morfologia", "10^9/L", "1.0", "3.0"),
-                createTest("MONO", "Monocyty", "Morfologia", "10^9/L", "0.2", "1.0"),
-                createTest("EO", "Eozynofile", "Morfologia", "10^9/L", "0.0", "0.5"),
-                createTest("BASO", "Bazofile", "Morfologia", "10^9/L", "0.0", "0.1"),
-                createTest("RET", "Retikulocyty", "Morfologia", "%", "0.5", "1.5"),
+    public void run(String... args) throws IOException {
+        List<TestTypeDictionaryEntry> authoritativeTests = loadDictionaryEntries();
 
-                // --- BIOCHEMIA ---
-                createTest("GLU", "Glukoza", "Biochemia", "mg/dL", "70.0", "99.0"),
-                createTest("UREA", "Mocznik", "Biochemia", "mg/dL", "15.0", "45.0"),
-                createTest("CREA", "Kreatynina", "Biochemia", "mg/dL", "0.5", "1.2"),
-                createTest("UA", "Kwas moczowy", "Biochemia", "mg/dL", "3.5", "7.2"),
-                createTest("TP", "Białko całkowite", "Biochemia", "g/dL", "6.6", "8.7"),
-                createTest("ALB", "Albuminy", "Biochemia", "g/dL", "3.5", "5.2"),
-                createTest("BIL-T", "Bilirubina całkowita", "Biochemia", "mg/dL", "0.2", "1.2"),
-                createTest("BIL-D", "Bilirubina bezpośrednia", "Biochemia", "mg/dL", "0.0", "0.3"),
-                createTest("CRP", "Białko C-reaktywne (CRP)", "Biochemia", "mg/L", "0.0", "5.0"),
-                createTest("HBA1C", "Hemoglobina glikowana (HbA1c)", "Biochemia", "%", "4.0", "5.6"),
-                createTest("HOMO", "Homocysteina", "Biochemia", "umol/L", "5.0", "15.0"),
-                createTest("LACT", "Mleczany", "Biochemia", "mmol/L", "0.5", "2.2"),
-                createTest("FRUC", "Fruktozamina", "Biochemia", "umol/L", "200.0", "285.0"),
-
-                // --- ENZYMY ---
-                createTest("AST", "Aminotransferaza asparaginianowa (AST)", "Enzymy", "U/L", "5.0", "40.0"),
-                createTest("ALT", "Aminotransferaza alaninowa (ALT)", "Enzymy", "U/L", "5.0", "40.0"),
-                createTest("ALP", "Fosfataza alkaliczna (ALP)", "Enzymy", "U/L", "40.0", "120.0"),
-                createTest("GGTP", "Gamma-glutamylotranspeptydaza", "Enzymy", "U/L", "10.0", "40.0"),
-                createTest("LDH", "Dehydrogenaza mleczanowa", "Enzymy", "U/L", "140.0", "280.0"),
-                createTest("CK", "Kinaza kreatynowa (CK)", "Enzymy", "U/L", "30.0", "200.0"),
-                createTest("CK-MB", "Izoenzym MB kinazy kreatynowej", "Enzymy", "U/L", "0.0", "24.0"),
-                createTest("AMYL", "Amylaza", "Enzymy", "U/L", "28.0", "100.0"),
-                createTest("LIP", "Lipaza", "Enzymy", "U/L", "13.0", "60.0"),
-                createTest("CHOL-E", "Cholinoesteraza", "Enzymy", "U/L", "5300.0", "12900.0"),
-
-                // --- JONOGRAM / MIKROELEMENTY ---
-                createTest("NA", "Sód (Na)", "Jonogram", "mmol/L", "135.0", "145.0"),
-                createTest("K", "Potas (K)", "Jonogram", "mmol/L", "3.5", "5.1"),
-                createTest("CL", "Chlorki (Cl)", "Jonogram", "mmol/L", "98.0", "107.0"),
-                createTest("CA", "Wapń całkowity (Ca)", "Jonogram", "mg/dL", "8.5", "10.5"),
-                createTest("CA-ION", "Wapń zjonizowany", "Jonogram", "mmol/L", "1.1", "1.3"),
-                createTest("MG", "Magnez (Mg)", "Jonogram", "mg/dL", "1.6", "2.6"),
-                createTest("P", "Fosfor nieorganiczny (P)", "Jonogram", "mg/dL", "2.5", "4.5"),
-                createTest("FE", "Żelazo (Fe)", "Jonogram", "ug/dL", "60.0", "170.0"),
-                createTest("CU", "Miedź (Cu)", "Jonogram", "ug/dL", "70.0", "140.0"),
-                createTest("ZN", "Cynk (Zn)", "Jonogram", "ug/dL", "70.0", "120.0"),
-
-                // --- LIPIDOGRAM ---
-                createTest("CHOL", "Cholesterol całkowity", "Lipidogram", "mg/dL", "115.0", "190.0"),
-                createTest("HDL", "Cholesterol HDL", "Lipidogram", "mg/dL", "40.0", "100.0"),
-                createTest("LDL", "Cholesterol LDL", "Lipidogram", "mg/dL", "0.0", "115.0"),
-                createTest("TG", "Triglicerydy", "Lipidogram", "mg/dL", "0.0", "150.0"),
-                createTest("NON-HDL", "Cholesterol nie-HDL", "Lipidogram", "mg/dL", "0.0", "130.0"),
-
-                // --- HORMONY TARCZYCY ---
-                createTest("TSH", "Hormon tyreotropowy (TSH)", "Hormony", "uIU/mL", "0.27", "4.20"),
-                createTest("FT3", "Wolna trijodotyronina (FT3)", "Hormony", "pg/mL", "2.0", "4.4"),
-                createTest("FT4", "Wolna tyroksyna (FT4)", "Hormony", "ng/dL", "0.93", "1.70"),
-                createTest("ANTI-TPO", "Przeciwciała anty-TPO", "Immunologia", "IU/mL", "0.0", "34.0"),
-                createTest("ANTI-TG", "Przeciwciała anty-TG", "Immunologia", "IU/mL", "0.0", "115.0"),
-
-                // --- HORMONY PŁCIOWE I ROZRODCZOŚĆ ---
-                createTest("FSH", "Hormon folikulotropowy (FSH)", "Hormony", "mIU/mL", "1.5", "12.4"),
-                createTest("LH", "Hormon luteinizujący (LH)", "Hormony", "mIU/mL", "1.7", "8.6"),
-                createTest("E2", "Estradiol", "Hormony", "pg/mL", "12.0", "166.0"),
-                createTest("PROG", "Progesteron", "Hormony", "ng/mL", "0.2", "1.5"),
-                createTest("PRL", "Prolaktyna", "Hormony", "ng/mL", "4.7", "23.3"),
-                createTest("TESTO", "Testosteron całkowity", "Hormony", "ng/dL", "250.0", "800.0"),
-                createTest("TESTO-F", "Testosteron wolny", "Hormony", "pg/mL", "1.0", "28.0"),
-                createTest("SHBG", "Białko wiążące hormony płciowe", "Hormony", "nmol/L", "18.0", "114.0"),
-                createTest("DHEA-S", "Siarczan DHEA", "Hormony", "ug/dL", "35.0", "430.0"),
-                createTest("BHCG", "Beta-hCG", "Hormony", "mIU/mL", "0.0", "5.0"),
-
-                // --- INNE HORMONY ---
-                createTest("CORT", "Kortyzol (rano)", "Hormony", "ug/dL", "6.2", "19.4"),
-                createTest("INS", "Insulina (na czczo)", "Hormony", "uIU/mL", "2.6", "24.9"),
-                createTest("PTH", "Parathormon (PTH)", "Hormony", "pg/mL", "15.0", "65.0"),
-                createTest("ACTH", "Hormon adrenokortykotropowy", "Hormony", "pg/mL", "7.2", "63.3"),
-                createTest("ALD", "Aldosteron", "Hormony", "ng/dL", "3.0", "16.0"),
-
-                // --- GOSPODARKA ŻELAZEM I WITAMINY ---
-                createTest("FERR", "Ferrytyna", "Witaminy", "ng/mL", "15.0", "300.0"),
-                createTest("TIBC", "Całkowita zdolność wiązania Fe", "Witaminy", "ug/dL", "250.0", "400.0"),
-                createTest("TRANS", "Transferryna", "Witaminy", "mg/dL", "200.0", "360.0"),
-                createTest("VIT-D3", "Witamina D3 (25-OH)", "Witaminy", "ng/mL", "30.0", "50.0"),
-                createTest("VIT-B12", "Witamina B12", "Witaminy", "pg/mL", "197.0", "771.0"),
-                createTest("FOLIC", "Kwas foliowy", "Witaminy", "ng/mL", "4.6", "18.7"),
-
-                // --- KOAGULOLOGIA ---
-                createTest("PT", "Czas protrombinowy (PT)", "Koagulologia", "sek", "10.0", "14.0"),
-                createTest("INR", "Wskaźnik INR", "Koagulologia", "-", "0.8", "1.2"),
-                createTest("APTT", "Czas kaolinowo-kefalinowy", "Koagulologia", "sek", "26.0", "40.0"),
-                createTest("FIBR", "Fibrynogen", "Koagulologia", "g/L", "1.8", "3.5"),
-                createTest("D-DIM", "D-dimery", "Koagulologia", "ug/mL", "0.0", "0.5"),
-
-                // --- MARKERY NOWOTWOROWE ---
-                createTest("PSA", "PSA całkowity", "Markery", "ng/mL", "0.0", "4.0"),
-                createTest("FPSA", "PSA wolny", "Markery", "ng/mL", "0.0", "1.0"),
-                createTest("CEA", "Antygen karcinoembrionalny (CEA)", "Markery", "ng/mL", "0.0", "5.0"),
-                createTest("CA125", "Antygen nowotworowy 125", "Markery", "U/mL", "0.0", "35.0"),
-                createTest("CA153", "Antygen nowotworowy 15-3", "Markery", "U/mL", "0.0", "25.0"),
-                createTest("CA199", "Antygen nowotworowy 19-9", "Markery", "U/mL", "0.0", "37.0"),
-                createTest("AFP", "Alfa-fetoproteina (AFP)", "Markery", "IU/mL", "0.0", "5.8"),
-                createTest("HE4", "Białko HE4", "Markery", "pmol/L", "0.0", "70.0"),
-                createTest("CYFRA", "Cyfra 21-1", "Markery", "ng/mL", "0.0", "3.3"),
-                createTest("SCC", "Antygen SCC", "Markery", "ng/mL", "0.0", "1.5"),
-
-                // --- IMMUNOLOGIA I SEROLOGIA ---
-                createTest("IGG", "Immunoglobuliny IgG", "Immunologia", "g/L", "7.0", "16.0"),
-                createTest("IGA", "Immunoglobuliny IgA", "Immunologia", "g/L", "0.7", "4.0"),
-                createTest("IGM", "Immunoglobuliny IgM", "Immunologia", "g/L", "0.4", "2.3"),
-                createTest("IGE", "Immunoglobuliny IgE całkowite", "Immunologia", "IU/mL", "0.0", "100.0"),
-                createTest("RF", "Czynnik reumatoidalny (RF)", "Immunologia", "IU/mL", "0.0", "14.0"),
-                createTest("ASO", "Odczyn antystreptolizynowy (ASO)", "Immunologia", "IU/mL", "0.0", "200.0"),
-
-                // --- PARAMETRY MOCZU (Przykładowe liczbowe) ---
-                createTest("U-PH", "pH moczu", "Mocz", "-", "5.0", "8.0"),
-                createTest("U-SG", "Ciężar właściwy moczu", "Mocz", "g/cm3", "1.015", "1.025"),
-                createTest("U-PRO", "Białko w moczu", "Mocz", "mg/dL", "0.0", "15.0"),
-                createTest("U-GLU", "Glukoza w moczu", "Mocz", "mg/dL", "0.0", "15.0"),
-                createTest("U-KET", "Ciała ketonowe w moczu", "Mocz", "mg/dL", "0.0", "5.0"),
-                createTest("U-URO", "Urobilinogen", "Mocz", "mg/dL", "0.1", "1.0"),
-                createTest("U-BIL", "Bilirubina w moczu", "Mocz", "mg/dL", "0.0", "0.2"),
-
-                // --- GAZOMETRIA KRWI ---
-                createTest("PH", "pH krwi", "Gazometria", "-", "7.35", "7.45"),
-                createTest("PCO2", "Ciśnienie parcjalne CO2", "Gazometria", "mmHg", "35.0", "45.0"),
-                createTest("PO2", "Ciśnienie parcjalne O2", "Gazometria", "mmHg", "75.0", "100.0"),
-                createTest("HCO3", "Wodorowęglany", "Gazometria", "mmol/L", "22.0", "26.0"),
-                createTest("BE", "Nadmiar zasad (Base Excess)", "Gazometria", "mmol/L", "-2.0", "2.0")
-        );
-
-        for (TestType authTest : authoritativeTests) {
+        for (TestTypeDictionaryEntry entry : authoritativeTests) {
+            TestType authTest = createTest(entry);
             TestType existing = testTypeRepository.findByTestCode(authTest.getTestCode()).orElse(null);
 
             if (existing == null) {
@@ -180,18 +56,66 @@ public class DictionarySeeder implements CommandLineRunner {
             }
         }
 
-        System.out.println("Twardy słownik badań (MDM) został pomyślnie załadowany i zsynchronizowany");
+        System.out.println("Słownik badań (MDM) został pomyślnie załadowany i zsynchronizowany z: " + dictionaryPath);
     }
 
-    // Metoda pomocnicza do łatwego tworzenia obiektów badań w kodzie
-    private TestType createTest(String code, String name, String category, String unit, String min, String max) {
+    private List<TestTypeDictionaryEntry> loadDictionaryEntries() throws IOException {
+        Resource dictionaryResource = resourceLoader.getResource(dictionaryPath);
+        if (!dictionaryResource.exists()) {
+            throw new IllegalStateException("Nie znaleziono pliku słownika badań: " + dictionaryPath);
+        }
+
+        List<TestTypeDictionaryEntry> entries;
+        try (InputStream dictionaryStream = dictionaryResource.getInputStream()) {
+            entries = objectMapper.readValue(dictionaryStream, new TypeReference<>() {});
+        }
+        validateDictionary(entries);
+        return entries;
+    }
+
+    private void validateDictionary(List<TestTypeDictionaryEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            throw new IllegalStateException("Plik słownika badań jest pusty: " + dictionaryPath);
+        }
+
+        Set<String> codes = new HashSet<>();
+        for (TestTypeDictionaryEntry entry : entries) {
+            if (entry == null) {
+                throw new IllegalStateException("Plik słownika badań zawiera pusty wpis: " + dictionaryPath);
+            }
+
+            String code = normalize(entry.getTestCode());
+            if (code == null) {
+                throw new IllegalStateException("Wpis słownika badań nie zawiera pola testCode: " + dictionaryPath);
+            }
+            if (!codes.add(code)) {
+                throw new IllegalStateException("Plik słownika badań zawiera zduplikowany testCode: " + code);
+            }
+            if (normalize(entry.getTestName()) == null) {
+                throw new IllegalStateException("Wpis słownika badań " + code + " nie zawiera pola testName");
+            }
+            if (entry.getNormMin() != null && entry.getNormMax() != null
+                    && entry.getNormMin().compareTo(entry.getNormMax()) > 0) {
+                throw new IllegalStateException("Wpis słownika badań " + code + " ma normMin większe od normMax");
+            }
+        }
+    }
+
+    private TestType createTest(TestTypeDictionaryEntry entry) {
         TestType t = new TestType();
-        t.setTestCode(code);
-        t.setTestName(name);
-        t.setCategoryName(category);
-        t.setUnit(unit);
-        t.setNormMin(new BigDecimal(min));
-        t.setNormMax(new BigDecimal(max));
+        t.setTestCode(normalize(entry.getTestCode()));
+        t.setTestName(normalize(entry.getTestName()));
+        t.setCategoryName(normalize(entry.getCategoryName()));
+        t.setUnit(normalize(entry.getUnit()));
+        t.setNormMin(entry.getNormMin());
+        t.setNormMax(entry.getNormMax());
         return t;
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 }

--- a/backend/src/main/java/com/medicalyticsss/backend/seeder/DictionarySeeder.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/seeder/DictionarySeeder.java
@@ -21,15 +21,14 @@ import java.util.Set;
 public class DictionarySeeder implements CommandLineRunner {
 
     private final TestTypeRepository testTypeRepository;
-    private final ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private final ResourceLoader resourceLoader;
 
     @Value("${dictionary.tests.path:classpath:dictionaries/test-types.json}")
     private String dictionaryPath;
 
-    public DictionarySeeder(TestTypeRepository testTypeRepository, ObjectMapper objectMapper, ResourceLoader resourceLoader) {
+    public DictionarySeeder(TestTypeRepository testTypeRepository, ResourceLoader resourceLoader) {
         this.testTypeRepository = testTypeRepository;
-        this.objectMapper = objectMapper;
         this.resourceLoader = resourceLoader;
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.jpa.show-sql=true
 spring.flyway.enabled=true
 logging.level.org.flywaydb=DEBUG
 file.upload-dir=uploads
+dictionary.tests.path=classpath:dictionaries/test-types.json

--- a/backend/src/main/resources/dictionaries/test-types.json
+++ b/backend/src/main/resources/dictionaries/test-types.json
@@ -1,0 +1,898 @@
+[
+  {
+    "testCode": "WBC",
+    "testName": "Leukocyty",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "4.0",
+    "normMax": "10.0"
+  },
+  {
+    "testCode": "RBC",
+    "testName": "Erytrocyty",
+    "categoryName": "Morfologia",
+    "unit": "10^12/L",
+    "normMin": "4.2",
+    "normMax": "5.4"
+  },
+  {
+    "testCode": "HGB",
+    "testName": "Hemoglobina",
+    "categoryName": "Morfologia",
+    "unit": "g/dL",
+    "normMin": "12.0",
+    "normMax": "16.0"
+  },
+  {
+    "testCode": "HCT",
+    "testName": "Hematokryt",
+    "categoryName": "Morfologia",
+    "unit": "%",
+    "normMin": "37.0",
+    "normMax": "47.0"
+  },
+  {
+    "testCode": "MCV",
+    "testName": "Średnia objętość krwinki (MCV)",
+    "categoryName": "Morfologia",
+    "unit": "fL",
+    "normMin": "80.0",
+    "normMax": "100.0"
+  },
+  {
+    "testCode": "MCH",
+    "testName": "Średnia masa Hb w krwince (MCH)",
+    "categoryName": "Morfologia",
+    "unit": "pg",
+    "normMin": "27.0",
+    "normMax": "32.0"
+  },
+  {
+    "testCode": "MCHC",
+    "testName": "Średnie stężenie Hb (MCHC)",
+    "categoryName": "Morfologia",
+    "unit": "g/dL",
+    "normMin": "32.0",
+    "normMax": "36.0"
+  },
+  {
+    "testCode": "PLT",
+    "testName": "Płytki krwi",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "150.0",
+    "normMax": "400.0"
+  },
+  {
+    "testCode": "RDW",
+    "testName": "Rozkład objętości erytrocytów",
+    "categoryName": "Morfologia",
+    "unit": "%",
+    "normMin": "11.5",
+    "normMax": "14.5"
+  },
+  {
+    "testCode": "NEUT",
+    "testName": "Neutrofile",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "2.0",
+    "normMax": "7.0"
+  },
+  {
+    "testCode": "LYMPH",
+    "testName": "Limfocyty",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "1.0",
+    "normMax": "3.0"
+  },
+  {
+    "testCode": "MONO",
+    "testName": "Monocyty",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "0.2",
+    "normMax": "1.0"
+  },
+  {
+    "testCode": "EO",
+    "testName": "Eozynofile",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "0.0",
+    "normMax": "0.5"
+  },
+  {
+    "testCode": "BASO",
+    "testName": "Bazofile",
+    "categoryName": "Morfologia",
+    "unit": "10^9/L",
+    "normMin": "0.0",
+    "normMax": "0.1"
+  },
+  {
+    "testCode": "RET",
+    "testName": "Retikulocyty",
+    "categoryName": "Morfologia",
+    "unit": "%",
+    "normMin": "0.5",
+    "normMax": "1.5"
+  },
+  {
+    "testCode": "GLU",
+    "testName": "Glukoza",
+    "categoryName": "Biochemia",
+    "unit": "mg/dL",
+    "normMin": "70.0",
+    "normMax": "99.0"
+  },
+  {
+    "testCode": "UREA",
+    "testName": "Mocznik",
+    "categoryName": "Biochemia",
+    "unit": "mg/dL",
+    "normMin": "15.0",
+    "normMax": "45.0"
+  },
+  {
+    "testCode": "CREA",
+    "testName": "Kreatynina",
+    "categoryName": "Biochemia",
+    "unit": "mg/dL",
+    "normMin": "0.5",
+    "normMax": "1.2"
+  },
+  {
+    "testCode": "UA",
+    "testName": "Kwas moczowy",
+    "categoryName": "Biochemia",
+    "unit": "mg/dL",
+    "normMin": "3.5",
+    "normMax": "7.2"
+  },
+  {
+    "testCode": "TP",
+    "testName": "Białko całkowite",
+    "categoryName": "Biochemia",
+    "unit": "g/dL",
+    "normMin": "6.6",
+    "normMax": "8.7"
+  },
+  {
+    "testCode": "ALB",
+    "testName": "Albuminy",
+    "categoryName": "Biochemia",
+    "unit": "g/dL",
+    "normMin": "3.5",
+    "normMax": "5.2"
+  },
+  {
+    "testCode": "BIL-T",
+    "testName": "Bilirubina całkowita",
+    "categoryName": "Biochemia",
+    "unit": "mg/dL",
+    "normMin": "0.2",
+    "normMax": "1.2"
+  },
+  {
+    "testCode": "BIL-D",
+    "testName": "Bilirubina bezpośrednia",
+    "categoryName": "Biochemia",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "0.3"
+  },
+  {
+    "testCode": "CRP",
+    "testName": "Białko C-reaktywne (CRP)",
+    "categoryName": "Biochemia",
+    "unit": "mg/L",
+    "normMin": "0.0",
+    "normMax": "5.0"
+  },
+  {
+    "testCode": "HBA1C",
+    "testName": "Hemoglobina glikowana (HbA1c)",
+    "categoryName": "Biochemia",
+    "unit": "%",
+    "normMin": "4.0",
+    "normMax": "5.6"
+  },
+  {
+    "testCode": "HOMO",
+    "testName": "Homocysteina",
+    "categoryName": "Biochemia",
+    "unit": "umol/L",
+    "normMin": "5.0",
+    "normMax": "15.0"
+  },
+  {
+    "testCode": "LACT",
+    "testName": "Mleczany",
+    "categoryName": "Biochemia",
+    "unit": "mmol/L",
+    "normMin": "0.5",
+    "normMax": "2.2"
+  },
+  {
+    "testCode": "FRUC",
+    "testName": "Fruktozamina",
+    "categoryName": "Biochemia",
+    "unit": "umol/L",
+    "normMin": "200.0",
+    "normMax": "285.0"
+  },
+  {
+    "testCode": "AST",
+    "testName": "Aminotransferaza asparaginianowa (AST)",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "5.0",
+    "normMax": "40.0"
+  },
+  {
+    "testCode": "ALT",
+    "testName": "Aminotransferaza alaninowa (ALT)",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "5.0",
+    "normMax": "40.0"
+  },
+  {
+    "testCode": "ALP",
+    "testName": "Fosfataza alkaliczna (ALP)",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "40.0",
+    "normMax": "120.0"
+  },
+  {
+    "testCode": "GGTP",
+    "testName": "Gamma-glutamylotranspeptydaza",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "10.0",
+    "normMax": "40.0"
+  },
+  {
+    "testCode": "LDH",
+    "testName": "Dehydrogenaza mleczanowa",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "140.0",
+    "normMax": "280.0"
+  },
+  {
+    "testCode": "CK",
+    "testName": "Kinaza kreatynowa (CK)",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "30.0",
+    "normMax": "200.0"
+  },
+  {
+    "testCode": "CK-MB",
+    "testName": "Izoenzym MB kinazy kreatynowej",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "0.0",
+    "normMax": "24.0"
+  },
+  {
+    "testCode": "AMYL",
+    "testName": "Amylaza",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "28.0",
+    "normMax": "100.0"
+  },
+  {
+    "testCode": "LIP",
+    "testName": "Lipaza",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "13.0",
+    "normMax": "60.0"
+  },
+  {
+    "testCode": "CHOL-E",
+    "testName": "Cholinoesteraza",
+    "categoryName": "Enzymy",
+    "unit": "U/L",
+    "normMin": "5300.0",
+    "normMax": "12900.0"
+  },
+  {
+    "testCode": "NA",
+    "testName": "Sód (Na)",
+    "categoryName": "Jonogram",
+    "unit": "mmol/L",
+    "normMin": "135.0",
+    "normMax": "145.0"
+  },
+  {
+    "testCode": "K",
+    "testName": "Potas (K)",
+    "categoryName": "Jonogram",
+    "unit": "mmol/L",
+    "normMin": "3.5",
+    "normMax": "5.1"
+  },
+  {
+    "testCode": "CL",
+    "testName": "Chlorki (Cl)",
+    "categoryName": "Jonogram",
+    "unit": "mmol/L",
+    "normMin": "98.0",
+    "normMax": "107.0"
+  },
+  {
+    "testCode": "CA",
+    "testName": "Wapń całkowity (Ca)",
+    "categoryName": "Jonogram",
+    "unit": "mg/dL",
+    "normMin": "8.5",
+    "normMax": "10.5"
+  },
+  {
+    "testCode": "CA-ION",
+    "testName": "Wapń zjonizowany",
+    "categoryName": "Jonogram",
+    "unit": "mmol/L",
+    "normMin": "1.1",
+    "normMax": "1.3"
+  },
+  {
+    "testCode": "MG",
+    "testName": "Magnez (Mg)",
+    "categoryName": "Jonogram",
+    "unit": "mg/dL",
+    "normMin": "1.6",
+    "normMax": "2.6"
+  },
+  {
+    "testCode": "P",
+    "testName": "Fosfor nieorganiczny (P)",
+    "categoryName": "Jonogram",
+    "unit": "mg/dL",
+    "normMin": "2.5",
+    "normMax": "4.5"
+  },
+  {
+    "testCode": "FE",
+    "testName": "Żelazo (Fe)",
+    "categoryName": "Jonogram",
+    "unit": "ug/dL",
+    "normMin": "60.0",
+    "normMax": "170.0"
+  },
+  {
+    "testCode": "CU",
+    "testName": "Miedź (Cu)",
+    "categoryName": "Jonogram",
+    "unit": "ug/dL",
+    "normMin": "70.0",
+    "normMax": "140.0"
+  },
+  {
+    "testCode": "ZN",
+    "testName": "Cynk (Zn)",
+    "categoryName": "Jonogram",
+    "unit": "ug/dL",
+    "normMin": "70.0",
+    "normMax": "120.0"
+  },
+  {
+    "testCode": "CHOL",
+    "testName": "Cholesterol całkowity",
+    "categoryName": "Lipidogram",
+    "unit": "mg/dL",
+    "normMin": "115.0",
+    "normMax": "190.0"
+  },
+  {
+    "testCode": "HDL",
+    "testName": "Cholesterol HDL",
+    "categoryName": "Lipidogram",
+    "unit": "mg/dL",
+    "normMin": "40.0",
+    "normMax": "100.0"
+  },
+  {
+    "testCode": "LDL",
+    "testName": "Cholesterol LDL",
+    "categoryName": "Lipidogram",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "115.0"
+  },
+  {
+    "testCode": "TG",
+    "testName": "Triglicerydy",
+    "categoryName": "Lipidogram",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "150.0"
+  },
+  {
+    "testCode": "NON-HDL",
+    "testName": "Cholesterol nie-HDL",
+    "categoryName": "Lipidogram",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "130.0"
+  },
+  {
+    "testCode": "TSH",
+    "testName": "Hormon tyreotropowy (TSH)",
+    "categoryName": "Hormony",
+    "unit": "uIU/mL",
+    "normMin": "0.27",
+    "normMax": "4.20"
+  },
+  {
+    "testCode": "FT3",
+    "testName": "Wolna trijodotyronina (FT3)",
+    "categoryName": "Hormony",
+    "unit": "pg/mL",
+    "normMin": "2.0",
+    "normMax": "4.4"
+  },
+  {
+    "testCode": "FT4",
+    "testName": "Wolna tyroksyna (FT4)",
+    "categoryName": "Hormony",
+    "unit": "ng/dL",
+    "normMin": "0.93",
+    "normMax": "1.70"
+  },
+  {
+    "testCode": "ANTI-TPO",
+    "testName": "Przeciwciała anty-TPO",
+    "categoryName": "Immunologia",
+    "unit": "IU/mL",
+    "normMin": "0.0",
+    "normMax": "34.0"
+  },
+  {
+    "testCode": "ANTI-TG",
+    "testName": "Przeciwciała anty-TG",
+    "categoryName": "Immunologia",
+    "unit": "IU/mL",
+    "normMin": "0.0",
+    "normMax": "115.0"
+  },
+  {
+    "testCode": "FSH",
+    "testName": "Hormon folikulotropowy (FSH)",
+    "categoryName": "Hormony",
+    "unit": "mIU/mL",
+    "normMin": "1.5",
+    "normMax": "12.4"
+  },
+  {
+    "testCode": "LH",
+    "testName": "Hormon luteinizujący (LH)",
+    "categoryName": "Hormony",
+    "unit": "mIU/mL",
+    "normMin": "1.7",
+    "normMax": "8.6"
+  },
+  {
+    "testCode": "E2",
+    "testName": "Estradiol",
+    "categoryName": "Hormony",
+    "unit": "pg/mL",
+    "normMin": "12.0",
+    "normMax": "166.0"
+  },
+  {
+    "testCode": "PROG",
+    "testName": "Progesteron",
+    "categoryName": "Hormony",
+    "unit": "ng/mL",
+    "normMin": "0.2",
+    "normMax": "1.5"
+  },
+  {
+    "testCode": "PRL",
+    "testName": "Prolaktyna",
+    "categoryName": "Hormony",
+    "unit": "ng/mL",
+    "normMin": "4.7",
+    "normMax": "23.3"
+  },
+  {
+    "testCode": "TESTO",
+    "testName": "Testosteron całkowity",
+    "categoryName": "Hormony",
+    "unit": "ng/dL",
+    "normMin": "250.0",
+    "normMax": "800.0"
+  },
+  {
+    "testCode": "TESTO-F",
+    "testName": "Testosteron wolny",
+    "categoryName": "Hormony",
+    "unit": "pg/mL",
+    "normMin": "1.0",
+    "normMax": "28.0"
+  },
+  {
+    "testCode": "SHBG",
+    "testName": "Białko wiążące hormony płciowe",
+    "categoryName": "Hormony",
+    "unit": "nmol/L",
+    "normMin": "18.0",
+    "normMax": "114.0"
+  },
+  {
+    "testCode": "DHEA-S",
+    "testName": "Siarczan DHEA",
+    "categoryName": "Hormony",
+    "unit": "ug/dL",
+    "normMin": "35.0",
+    "normMax": "430.0"
+  },
+  {
+    "testCode": "BHCG",
+    "testName": "Beta-hCG",
+    "categoryName": "Hormony",
+    "unit": "mIU/mL",
+    "normMin": "0.0",
+    "normMax": "5.0"
+  },
+  {
+    "testCode": "CORT",
+    "testName": "Kortyzol (rano)",
+    "categoryName": "Hormony",
+    "unit": "ug/dL",
+    "normMin": "6.2",
+    "normMax": "19.4"
+  },
+  {
+    "testCode": "INS",
+    "testName": "Insulina (na czczo)",
+    "categoryName": "Hormony",
+    "unit": "uIU/mL",
+    "normMin": "2.6",
+    "normMax": "24.9"
+  },
+  {
+    "testCode": "PTH",
+    "testName": "Parathormon (PTH)",
+    "categoryName": "Hormony",
+    "unit": "pg/mL",
+    "normMin": "15.0",
+    "normMax": "65.0"
+  },
+  {
+    "testCode": "ACTH",
+    "testName": "Hormon adrenokortykotropowy",
+    "categoryName": "Hormony",
+    "unit": "pg/mL",
+    "normMin": "7.2",
+    "normMax": "63.3"
+  },
+  {
+    "testCode": "ALD",
+    "testName": "Aldosteron",
+    "categoryName": "Hormony",
+    "unit": "ng/dL",
+    "normMin": "3.0",
+    "normMax": "16.0"
+  },
+  {
+    "testCode": "FERR",
+    "testName": "Ferrytyna",
+    "categoryName": "Witaminy",
+    "unit": "ng/mL",
+    "normMin": "15.0",
+    "normMax": "300.0"
+  },
+  {
+    "testCode": "TIBC",
+    "testName": "Całkowita zdolność wiązania Fe",
+    "categoryName": "Witaminy",
+    "unit": "ug/dL",
+    "normMin": "250.0",
+    "normMax": "400.0"
+  },
+  {
+    "testCode": "TRANS",
+    "testName": "Transferryna",
+    "categoryName": "Witaminy",
+    "unit": "mg/dL",
+    "normMin": "200.0",
+    "normMax": "360.0"
+  },
+  {
+    "testCode": "VIT-D3",
+    "testName": "Witamina D3 (25-OH)",
+    "categoryName": "Witaminy",
+    "unit": "ng/mL",
+    "normMin": "30.0",
+    "normMax": "50.0"
+  },
+  {
+    "testCode": "VIT-B12",
+    "testName": "Witamina B12",
+    "categoryName": "Witaminy",
+    "unit": "pg/mL",
+    "normMin": "197.0",
+    "normMax": "771.0"
+  },
+  {
+    "testCode": "FOLIC",
+    "testName": "Kwas foliowy",
+    "categoryName": "Witaminy",
+    "unit": "ng/mL",
+    "normMin": "4.6",
+    "normMax": "18.7"
+  },
+  {
+    "testCode": "PT",
+    "testName": "Czas protrombinowy (PT)",
+    "categoryName": "Koagulologia",
+    "unit": "sek",
+    "normMin": "10.0",
+    "normMax": "14.0"
+  },
+  {
+    "testCode": "INR",
+    "testName": "Wskaźnik INR",
+    "categoryName": "Koagulologia",
+    "unit": "-",
+    "normMin": "0.8",
+    "normMax": "1.2"
+  },
+  {
+    "testCode": "APTT",
+    "testName": "Czas kaolinowo-kefalinowy",
+    "categoryName": "Koagulologia",
+    "unit": "sek",
+    "normMin": "26.0",
+    "normMax": "40.0"
+  },
+  {
+    "testCode": "FIBR",
+    "testName": "Fibrynogen",
+    "categoryName": "Koagulologia",
+    "unit": "g/L",
+    "normMin": "1.8",
+    "normMax": "3.5"
+  },
+  {
+    "testCode": "D-DIM",
+    "testName": "D-dimery",
+    "categoryName": "Koagulologia",
+    "unit": "ug/mL",
+    "normMin": "0.0",
+    "normMax": "0.5"
+  },
+  {
+    "testCode": "PSA",
+    "testName": "PSA całkowity",
+    "categoryName": "Markery",
+    "unit": "ng/mL",
+    "normMin": "0.0",
+    "normMax": "4.0"
+  },
+  {
+    "testCode": "FPSA",
+    "testName": "PSA wolny",
+    "categoryName": "Markery",
+    "unit": "ng/mL",
+    "normMin": "0.0",
+    "normMax": "1.0"
+  },
+  {
+    "testCode": "CEA",
+    "testName": "Antygen karcinoembrionalny (CEA)",
+    "categoryName": "Markery",
+    "unit": "ng/mL",
+    "normMin": "0.0",
+    "normMax": "5.0"
+  },
+  {
+    "testCode": "CA125",
+    "testName": "Antygen nowotworowy 125",
+    "categoryName": "Markery",
+    "unit": "U/mL",
+    "normMin": "0.0",
+    "normMax": "35.0"
+  },
+  {
+    "testCode": "CA153",
+    "testName": "Antygen nowotworowy 15-3",
+    "categoryName": "Markery",
+    "unit": "U/mL",
+    "normMin": "0.0",
+    "normMax": "25.0"
+  },
+  {
+    "testCode": "CA199",
+    "testName": "Antygen nowotworowy 19-9",
+    "categoryName": "Markery",
+    "unit": "U/mL",
+    "normMin": "0.0",
+    "normMax": "37.0"
+  },
+  {
+    "testCode": "AFP",
+    "testName": "Alfa-fetoproteina (AFP)",
+    "categoryName": "Markery",
+    "unit": "IU/mL",
+    "normMin": "0.0",
+    "normMax": "5.8"
+  },
+  {
+    "testCode": "HE4",
+    "testName": "Białko HE4",
+    "categoryName": "Markery",
+    "unit": "pmol/L",
+    "normMin": "0.0",
+    "normMax": "70.0"
+  },
+  {
+    "testCode": "CYFRA",
+    "testName": "Cyfra 21-1",
+    "categoryName": "Markery",
+    "unit": "ng/mL",
+    "normMin": "0.0",
+    "normMax": "3.3"
+  },
+  {
+    "testCode": "SCC",
+    "testName": "Antygen SCC",
+    "categoryName": "Markery",
+    "unit": "ng/mL",
+    "normMin": "0.0",
+    "normMax": "1.5"
+  },
+  {
+    "testCode": "IGG",
+    "testName": "Immunoglobuliny IgG",
+    "categoryName": "Immunologia",
+    "unit": "g/L",
+    "normMin": "7.0",
+    "normMax": "16.0"
+  },
+  {
+    "testCode": "IGA",
+    "testName": "Immunoglobuliny IgA",
+    "categoryName": "Immunologia",
+    "unit": "g/L",
+    "normMin": "0.7",
+    "normMax": "4.0"
+  },
+  {
+    "testCode": "IGM",
+    "testName": "Immunoglobuliny IgM",
+    "categoryName": "Immunologia",
+    "unit": "g/L",
+    "normMin": "0.4",
+    "normMax": "2.3"
+  },
+  {
+    "testCode": "IGE",
+    "testName": "Immunoglobuliny IgE całkowite",
+    "categoryName": "Immunologia",
+    "unit": "IU/mL",
+    "normMin": "0.0",
+    "normMax": "100.0"
+  },
+  {
+    "testCode": "RF",
+    "testName": "Czynnik reumatoidalny (RF)",
+    "categoryName": "Immunologia",
+    "unit": "IU/mL",
+    "normMin": "0.0",
+    "normMax": "14.0"
+  },
+  {
+    "testCode": "ASO",
+    "testName": "Odczyn antystreptolizynowy (ASO)",
+    "categoryName": "Immunologia",
+    "unit": "IU/mL",
+    "normMin": "0.0",
+    "normMax": "200.0"
+  },
+  {
+    "testCode": "U-PH",
+    "testName": "pH moczu",
+    "categoryName": "Mocz",
+    "unit": "-",
+    "normMin": "5.0",
+    "normMax": "8.0"
+  },
+  {
+    "testCode": "U-SG",
+    "testName": "Ciężar właściwy moczu",
+    "categoryName": "Mocz",
+    "unit": "g/cm3",
+    "normMin": "1.015",
+    "normMax": "1.025"
+  },
+  {
+    "testCode": "U-PRO",
+    "testName": "Białko w moczu",
+    "categoryName": "Mocz",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "15.0"
+  },
+  {
+    "testCode": "U-GLU",
+    "testName": "Glukoza w moczu",
+    "categoryName": "Mocz",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "15.0"
+  },
+  {
+    "testCode": "U-KET",
+    "testName": "Ciała ketonowe w moczu",
+    "categoryName": "Mocz",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "5.0"
+  },
+  {
+    "testCode": "U-URO",
+    "testName": "Urobilinogen",
+    "categoryName": "Mocz",
+    "unit": "mg/dL",
+    "normMin": "0.1",
+    "normMax": "1.0"
+  },
+  {
+    "testCode": "U-BIL",
+    "testName": "Bilirubina w moczu",
+    "categoryName": "Mocz",
+    "unit": "mg/dL",
+    "normMin": "0.0",
+    "normMax": "0.2"
+  },
+  {
+    "testCode": "PH",
+    "testName": "pH krwi",
+    "categoryName": "Gazometria",
+    "unit": "-",
+    "normMin": "7.35",
+    "normMax": "7.45"
+  },
+  {
+    "testCode": "PCO2",
+    "testName": "Ciśnienie parcjalne CO2",
+    "categoryName": "Gazometria",
+    "unit": "mmHg",
+    "normMin": "35.0",
+    "normMax": "45.0"
+  },
+  {
+    "testCode": "PO2",
+    "testName": "Ciśnienie parcjalne O2",
+    "categoryName": "Gazometria",
+    "unit": "mmHg",
+    "normMin": "75.0",
+    "normMax": "100.0"
+  },
+  {
+    "testCode": "HCO3",
+    "testName": "Wodorowęglany",
+    "categoryName": "Gazometria",
+    "unit": "mmol/L",
+    "normMin": "22.0",
+    "normMax": "26.0"
+  },
+  {
+    "testCode": "BE",
+    "testName": "Nadmiar zasad (Base Excess)",
+    "categoryName": "Gazometria",
+    "unit": "mmol/L",
+    "normMin": "-2.0",
+    "normMax": "2.0"
+  }
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,15 @@ Zarządzanie strukturą bazy danych w projekcie przejął **Flyway**. Zanim uruc
 1. W IntelliJ przejdź do folderu `backend/src/main/java/com/medicalyticsss/backend`.
 2. Otwórz klasę `Application` (główną klasę Spring Boot).
 3. Uruchom metodę `main` (zielony trójkąt "Run").
-4. W konsoli powinieneś zobaczyć komunikat o wymuszeniu uruchomienia Flywaya (skrypty same zbudują tabele w pustej bazie). Dodatkowo uruchomi się **DictionarySeeder**, który automatycznie załaduje twardy słownik 100 badań do bazy. Tomcat rozpocznie nasłuchiwanie na porcie `8080`. **NIE ZAMYKAJ TEJ KONSOLI.**
+4. W konsoli powinieneś zobaczyć komunikat o wymuszeniu uruchomienia Flywaya (skrypty same zbudują tabele w pustej bazie). Dodatkowo uruchomi się **DictionarySeeder**, który automatycznie załaduje słownik badań z pliku JSON do bazy. Tomcat rozpocznie nasłuchiwanie na porcie `8080`. **NIE ZAMYKAJ TEJ KONSOLI.**
+
+Domyślny słownik znajduje się w `backend/src/main/resources/dictionaries/test-types.json`. Możesz wskazać własny plik bez przebudowy aplikacji, ustawiając właściwość `dictionary.tests.path`, np.:
+
+```bash
+java -jar backend.jar --dictionary.tests.path=file:/sciezka/do/custom-test-types.json
+```
+
+Plik powinien być tablicą obiektów JSON z polami: `testCode`, `testName`, `categoryName`, `unit`, `normMin`, `normMax`.
 
 ### Krok 3: Uruchomienie Aplikacji Okienkowej (Frontend)
 1. Otwórz PRAWY panel **Maven** w IntelliJ.
@@ -92,7 +100,7 @@ Moduł obsługujący procesy hurtowni danych (Extract, Transform, Load) oraz bez
   * **Ścisła walidacja (Strict Validation):** System weryfikuje kompletność każdego wiersza. Brak chociażby jednego pola skutkuje odrzuceniem konkretnego rekordu i logowaniem go do tabeli błędów.
   * Zabezpiecza wrażliwe dane: zamienia PESEL na skrót SHA-256.
   * **Normalizacja MDM:** Nazwy placówek, miast i województw przed zapisem są formatowane (Title Case, usuwanie znaków specjalnych i podwójnych spacji), aby zapobiec duplikatom w wymiarze `dim_facility`.
-  * **Twardy Słownik (MDM):** Wymiar `dim_test_type` jest nienaruszalny. Pliki CSV dostarczają tylko wyniki pacjenta – do ewaluacji anomalii używane są wyłącznie twarde normy załadowane do bazy przez Seeder.
+  * **Słownik MDM:** Wymiar `dim_test_type` jest nienaruszalny. Pliki CSV dostarczają tylko wyniki pacjenta – do ewaluacji anomalii używane są wyłącznie normy załadowane do bazy przez Seeder z pliku JSON.
   * Sukcesy dopisuje do tabeli `fact_test_results`, a anomalie odrzuca do tabeli `processing_errors`.
   * Aktualizuje finalny status pliku (`SUCCESS`, `PARTIAL_SUCCESS` lub `ERROR`).
 * **Odpowiedź:** `200 OK` (`"Proces przetwarzania zakończony. Sprawdź status pliku."`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Projekt opiera się na klasycznej architekturze **Klient-Serwer**, rozdzielając
 * **Moduł ETL & MDM:** * **Strict Validation:** Klasa `CsvProcessingService` rygorystycznie waliduje kompletność danych wiersz po wierszu.
   * **String Sanitization:** Czyści i standaryzuje (Title Case) dane tekstowe "w locie", aby zapobiegać duplikatom.
   * Zapewnia anonimizację danych wrażliwych pacjentów (PESEL -> SHA-256).
-* **Dictionary Seeder:** Komponent ładujący twardy słownik referencyjny medycznych norm i badań podczas startu serwera, uodparniając bazę na błędne dane z zewnątrz.
+* **Dictionary Seeder:** Komponent ładujący referencyjny słownik medycznych norm i badań z konfigurowalnego pliku JSON podczas startu serwera, uodparniając bazę na błędne dane z zewnątrz.
 * **Silnik Raportowy BI (OLAP):** Zastąpił sztywne zapytania w pełni dynamicznym silnikiem opartym na **JPA Criteria API**. Wykorzystuje wzorzec **Whitelist** (Enumy), gwarantując całkowitą ochronę przed atakami SQL Injection. Samodzielnie rozwiązuje złączenia tabel (LEFT JOIN) oraz przetwarza rzutowanie typów dla zaawansowanych filtrów (klauzula WHERE).
 
 ### 3. Baza Danych (Model Gwiazdy + Moduł User)
@@ -30,7 +30,7 @@ Projekt opiera się na klasycznej architekturze **Klient-Serwer**, rozdzielając
   * **Użytkownicy:** Tabela `users` (id, username, password_hash).
   * **Tabele Faktów:** `fact_test_results` (centralny punkt modelu gwiazdy; wyniki badań powiązane z wymiarami i plikiem źródłowym).
   * **Tabele Wymiarów (Współdzielone):** * `dim_patient`, `dim_facility` – aktualizowane dynamicznie i transakcyjnie metodą *Upsert* (po uprzedniej normalizacji tekstów).
-    * `dim_test_type` – **Twardy Słownik (MDM)**, zasilany wyłącznie przez system, służący jako ostateczne źródło prawdy dla norm badawczych.
+    * `dim_test_type` – **Słownik MDM**, zasilany przez system z pliku wskazanego we właściwości `dictionary.tests.path`, służący jako ostateczne źródło prawdy dla norm badawczych.
   * **Historia:** `files_history` – kluczowa relacja z `users` (kolumna `user_id`). Przechowuje finalną nazwę pliku, datę wgrania (`uploadTime`) oraz status cyklu życia.
   * **Błędy:** `processing_errors` – szczegółowe logi anomalii w plikach chroniące przed przerwaniem globalnego procesu ETL.
 
@@ -47,7 +47,7 @@ Projekt opiera się na klasycznej architekturze **Klient-Serwer**, rozdzielając
 3. **Transformacja (ETL & Walidacja):** * Wiersze poddawane są "Żelaznej Bramce" (odrzucanie rekordów z brakującymi kolumnami).
 * Wrażliwe dane ulegają anonimizacji.
 * Teksty podlegają obróbce i czyszczeniu (String Sanitization).
-4. **Analiza i Weryfikacja (MDM):** System weryfikuje wymiary. Przy wyliczaniu flagi anomalii (`is_abnormal`), parser całkowicie ignoruje normy zawarte w pliku CSV, opierając analizę wyłącznie na *Twardym Słowniku* załadowanym do bazy przez system.
+4. **Analiza i Weryfikacja (MDM):** System weryfikuje wymiary. Przy wyliczaniu flagi anomalii (`is_abnormal`), parser całkowicie ignoruje normy zawarte w pliku CSV, opierając analizę wyłącznie na słowniku MDM załadowanym do bazy przez system z pliku JSON.
 5. **Finalizacja:** Prawidłowe wiersze zasilają model gwiazdy, a błędne lądują w tabeli anomalii. Status pliku ulega zmianie na `SUCCESS` lub `PARTIAL_SUCCESS`.
 6. **Wycofanie Zmian (Rollback / Soft Delete):** Po usunięciu pliku przez użytkownika, system transakcyjnie kasuje wyniki i błędy (`@Modifying`) chroniąc spójność raportów. Wymiary i słowniki celowo nie są usuwane. Rekord pliku otrzymuje status `DELETED`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move the default test type dictionary into a JSON resource file
- Load dictionary entries from configurable `dictionary.tests.path`
- Add validation for empty, duplicate, and invalid dictionary entries
- Avoid requiring Spring to autowire an `ObjectMapper` bean in `DictionarySeeder`
- Document how to override the dictionary file path

## Testing
- `bash ./mvnw -DskipTests compile` - passed
- `python3 -m json.tool src/main/resources/dictionaries/test-types.json >/dev/null` - passed
- `bash ./mvnw test` - failed because the test environment cannot connect to MariaDB / determine Hibernate dialect metadata
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34de2ae5-c033-46c5-a912-b0cde18539ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34de2ae5-c033-46c5-a912-b0cde18539ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

