### PR TITLE
Add CSV and PNG export options to reports

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -33,6 +33,11 @@
             <version>${javafx.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.mkpaz</groupId>
             <artifactId>atlantafx-base</artifactId>
             <version>2.0.1</version>

--- a/frontend/src/main/java/com/example/frontend/utils/ChartExportUtil.java
+++ b/frontend/src/main/java/com/example/frontend/utils/ChartExportUtil.java
@@ -1,0 +1,56 @@
+package com.example.frontend.utils;
+
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.SnapshotParameters;
+import javafx.scene.chart.Chart;
+import javafx.scene.image.WritableImage;
+import javafx.stage.FileChooser;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public final class ChartExportUtil {
+
+    private ChartExportUtil() {
+    }
+
+    public static Path exportChart(
+            Chart chart,
+            String dialogTitle,
+            String suggestedFileName
+    ) throws IOException {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle(dialogTitle);
+        fileChooser.setInitialFileName(withExtension(suggestedFileName, ".png"));
+        fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("PNG", "*.png"));
+
+        java.io.File selectedFile = fileChooser.showSaveDialog(ViewManager.getPrimaryStage());
+        if (selectedFile == null) {
+            return null;
+        }
+
+        Path targetPath = selectedFile.toPath();
+        if (!targetPath.getFileName().toString().toLowerCase().endsWith(".png")) {
+            targetPath = targetPath.resolveSibling(targetPath.getFileName() + ".png");
+        }
+
+        WritableImage snapshot = chart.snapshot(new SnapshotParameters(), null);
+        BufferedImage bufferedImage = SwingFXUtils.fromFXImage(snapshot, null);
+        boolean saved = ImageIO.write(bufferedImage, "png", targetPath.toFile());
+
+        if (!saved) {
+            throw new IOException("Brak obsługi zapisu obrazu PNG.");
+        }
+
+        return targetPath;
+    }
+
+    private static String withExtension(String fileName, String extension) {
+        if (fileName == null || fileName.isBlank()) {
+            return "chart" + extension;
+        }
+        return fileName.toLowerCase().endsWith(extension) ? fileName : fileName + extension;
+    }
+}

--- a/frontend/src/main/java/com/example/frontend/utils/CsvExportUtil.java
+++ b/frontend/src/main/java/com/example/frontend/utils/CsvExportUtil.java
@@ -1,0 +1,102 @@
+package com.example.frontend.utils;
+
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.stage.FileChooser;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class CsvExportUtil {
+
+    private CsvExportUtil() {
+    }
+
+    public static <T> Path exportTable(
+            TableView<T> table,
+            String dialogTitle,
+            String suggestedFileName
+    ) throws IOException {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle(dialogTitle);
+        fileChooser.setInitialFileName(withExtension(suggestedFileName, ".csv"));
+        fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("CSV", "*.csv"));
+
+        java.io.File selectedFile = fileChooser.showSaveDialog(ViewManager.getPrimaryStage());
+        if (selectedFile == null) {
+            return null;
+        }
+
+        Path targetPath = selectedFile.toPath();
+        if (!targetPath.getFileName().toString().toLowerCase().endsWith(".csv")) {
+            targetPath = targetPath.resolveSibling(targetPath.getFileName() + ".csv");
+        }
+        List<TableColumn<T, ?>> columns = getLeafColumns(table.getColumns());
+
+        try (BufferedWriter writer = Files.newBufferedWriter(targetPath, StandardCharsets.UTF_8)) {
+            writeRow(writer, columns.stream().map(TableColumn::getText).toList());
+            for (T item : table.getItems()) {
+                List<String> row = new ArrayList<>();
+                for (TableColumn<T, ?> column : columns) {
+                    Object value = column.getCellData(item);
+                    row.add(value == null ? "" : value.toString());
+                }
+                writeRow(writer, row);
+            }
+        }
+
+        return targetPath;
+    }
+
+    static void writeRow(BufferedWriter writer, List<String> values) throws IOException {
+        for (int index = 0; index < values.size(); index++) {
+            if (index > 0) {
+                writer.write(',');
+            }
+            writer.write(escape(values.get(index)));
+        }
+        writer.newLine();
+    }
+
+    static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String normalizedValue = value.replace("\r\n", "\n").replace('\r', '\n');
+        boolean requiresQuotes = normalizedValue.contains(",")
+                || normalizedValue.contains("\"")
+                || normalizedValue.contains("\n");
+
+        if (!requiresQuotes) {
+            return normalizedValue;
+        }
+
+        return "\"" + normalizedValue.replace("\"", "\"\"") + "\"";
+    }
+
+    private static <T> List<TableColumn<T, ?>> getLeafColumns(List<TableColumn<T, ?>> columns) {
+        List<TableColumn<T, ?>> leafColumns = new ArrayList<>();
+        for (TableColumn<T, ?> column : columns) {
+            if (column.getColumns().isEmpty()) {
+                leafColumns.add(column);
+                continue;
+            }
+
+            leafColumns.addAll(getLeafColumns(column.getColumns()));
+        }
+        return leafColumns;
+    }
+
+    private static String withExtension(String fileName, String extension) {
+        if (fileName == null || fileName.isBlank()) {
+            return "export" + extension;
+        }
+        return fileName.toLowerCase().endsWith(extension) ? fileName : fileName + extension;
+    }
+}

--- a/frontend/src/main/java/com/example/frontend/views/ReportView.java
+++ b/frontend/src/main/java/com/example/frontend/views/ReportView.java
@@ -97,7 +97,7 @@ public class ReportView {
 
         // ZAKŁADKA 3: Surowe Dane (Dynamiczny SELECT *)
         rawDataTable = new TableView<>();
-        rawDataTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        rawDataTable.setColumnResizePolicy(TableView.UNCONSTRAINED_RESIZE_POLICY);
         exportRawCsvButton = createExportButton(
                 "Eksportuj surowe dane CSV",
                 () -> exportTable(rawDataTable, "raport-surowe-dane.csv", "Surowe dane zostały zapisane do pliku CSV.")
@@ -455,7 +455,8 @@ public class ReportView {
                 return new SimpleObjectProperty<>(value != null ? value : "Brak danych");
             });
 
-            column.setPrefWidth(130);
+            column.setMinWidth(130);
+            column.setPrefWidth(160);
             table.getColumns().add(column);
         }
 

--- a/frontend/src/main/java/com/example/frontend/views/ReportView.java
+++ b/frontend/src/main/java/com/example/frontend/views/ReportView.java
@@ -7,16 +7,21 @@ import com.example.frontend.models.ReportFilter;
 import com.example.frontend.models.SeriesReportDataPoint;
 import com.example.frontend.models.SeriesReportRequest;
 import com.example.frontend.services.ReportService;
+import com.example.frontend.utils.ChartExportUtil;
+import com.example.frontend.utils.CsvExportUtil;
 import com.example.frontend.utils.ViewManager;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.chart.*;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,6 +33,10 @@ public class ReportView {
     private static TableView<Map<String, Object>> resultsTable;
     private static TableView<Map<String, Object>> rawDataTable; // Tabela dynamiczna (Słowniki)
     private static StackPane chartArea;
+    private static Chart currentChart;
+    private static Button exportReportCsvButton;
+    private static Button exportChartPngButton;
+    private static Button exportRawCsvButton;
 
     // Elementy paska bocznego
     private static ListView<String> groupByList;
@@ -68,17 +77,32 @@ public class ReportView {
         // ZAKŁADKA 1: Data Grid (Agregacje lub wybór bez agregacji)
         resultsTable = new TableView<>();
         resultsTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
-        Tab tableTab = new Tab("Raport (Tabela)", resultsTable);
+        exportReportCsvButton = createExportButton(
+                "Eksportuj raport CSV",
+                () -> exportTable(resultsTable, "raport-tabela.csv", "Raport został zapisany do pliku CSV.")
+        );
+        Tab tableTab = new Tab("Raport (Tabela)", createTabContent(exportReportCsvButton, resultsTable));
         tableTab.setClosable(false);
 
         // ZAKŁADKA 2: Wizualizacja (Wykresy)
-        chartArea = new StackPane(new Label("Skonfiguruj i wygeneruj raport, aby zobaczyć wykres"));
-        Tab chartTab = new Tab("Wizualizacja (Wykres)", chartArea);
+        chartArea = new StackPane();
+        chartArea.setPadding(new Insets(10));
+        exportChartPngButton = createExportButton(
+                "Eksportuj wykres PNG",
+                () -> exportChart("wykres-raportu.png")
+        );
+        setChartPlaceholder("Skonfiguruj i wygeneruj raport, aby zobaczyć wykres");
+        Tab chartTab = new Tab("Wizualizacja (Wykres)", createTabContent(exportChartPngButton, chartArea));
         chartTab.setClosable(false);
 
         // ZAKŁADKA 3: Surowe Dane (Dynamiczny SELECT *)
         rawDataTable = new TableView<>();
-        Tab rawTab = new Tab("Surowe Dane (SELECT *)", rawDataTable);
+        rawDataTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        exportRawCsvButton = createExportButton(
+                "Eksportuj surowe dane CSV",
+                () -> exportTable(rawDataTable, "raport-surowe-dane.csv", "Surowe dane zostały zapisane do pliku CSV.")
+        );
+        Tab rawTab = new Tab("Surowe Dane (SELECT *)", createTabContent(exportRawCsvButton, rawDataTable));
         rawTab.setClosable(false);
 
         // Złożenie zakładek
@@ -89,6 +113,91 @@ public class ReportView {
         root.setCenter(mainArea);
 
         return root;
+    }
+
+    private static VBox createTabContent(Button exportButton, Node content) {
+        HBox toolbar = new HBox(exportButton);
+        toolbar.setAlignment(Pos.CENTER_RIGHT);
+
+        VBox container = new VBox(10, toolbar, content);
+        VBox.setVgrow(content, Priority.ALWAYS);
+        return container;
+    }
+
+    private static Button createExportButton(String text, Runnable action) {
+        Button button = new Button(text);
+        button.getStyleClass().add(Styles.BUTTON_OUTLINED);
+        button.setDisable(true);
+        button.setOnAction(event -> action.run());
+        return button;
+    }
+
+    private static void exportTable(
+            TableView<Map<String, Object>> table,
+            String suggestedFileName,
+            String successMessage
+    ) {
+        if (table.getItems().isEmpty()) {
+            showAlert(Alert.AlertType.WARNING, "Brak danych", "Najpierw wygeneruj raport, aby zapisać go do CSV.");
+            return;
+        }
+
+        try {
+            Path savedPath = CsvExportUtil.exportTable(table, "Zapisz raport CSV", suggestedFileName);
+            if (savedPath != null) {
+                showAlert(Alert.AlertType.INFORMATION, "Eksport zakończony", successMessage + "\n\n" + savedPath.toAbsolutePath());
+            }
+        } catch (IOException exception) {
+            showAlert(Alert.AlertType.ERROR, "Błąd eksportu", "Nie udało się zapisać pliku CSV.\n\n" + exception.getMessage());
+        }
+    }
+
+    private static void exportChart(String suggestedFileName) {
+        if (currentChart == null) {
+            showAlert(Alert.AlertType.WARNING, "Brak wykresu", "Wygeneruj wykres przed zapisaniem go do pliku PNG.");
+            return;
+        }
+
+        try {
+            Path savedPath = ChartExportUtil.exportChart(currentChart, "Zapisz wykres PNG", suggestedFileName);
+            if (savedPath != null) {
+                showAlert(Alert.AlertType.INFORMATION, "Eksport zakończony", "Wykres został zapisany do pliku PNG.\n\n" + savedPath.toAbsolutePath());
+            }
+        } catch (IOException exception) {
+            showAlert(Alert.AlertType.ERROR, "Błąd eksportu", "Nie udało się zapisać wykresu do PNG.\n\n" + exception.getMessage());
+        }
+    }
+
+    private static void showAlert(Alert.AlertType type, String title, String message) {
+        Alert alert = new Alert(type);
+        alert.setTitle(title);
+        alert.setHeaderText(null);
+        alert.setContentText(message);
+        alert.showAndWait();
+    }
+
+    private static void setChartPlaceholder(String message) {
+        chartArea.getChildren().setAll(new Label(message));
+        currentChart = null;
+        updateExportButtonsState();
+    }
+
+    private static void setChartContent(Chart chart) {
+        chartArea.getChildren().setAll(chart);
+        currentChart = chart;
+        updateExportButtonsState();
+    }
+
+    private static void updateExportButtonsState() {
+        if (exportReportCsvButton != null) {
+            exportReportCsvButton.setDisable(resultsTable == null || resultsTable.getItems().isEmpty());
+        }
+        if (exportRawCsvButton != null) {
+            exportRawCsvButton.setDisable(rawDataTable == null || rawDataTable.getItems().isEmpty());
+        }
+        if (exportChartPngButton != null) {
+            exportChartPngButton.setDisable(currentChart == null);
+        }
     }
 
     private static VBox createSidebar() {
@@ -198,7 +307,7 @@ public class ReportView {
                 Platform.runLater(() -> updateChart(data));
             });
         } else {
-            chartArea.getChildren().setAll(new Label("Wybierz agregację, aby wygenerować wykres."));
+            setChartPlaceholder("Wybierz agregację, aby wygenerować wykres.");
         }
 
         // STRZAŁ PO SUROWE DANE
@@ -246,10 +355,8 @@ public class ReportView {
 
     private static void updateChart(List<ReportDataPoint> data) {
         // Wykres
-        chartArea.getChildren().clear();
-
         if (data.isEmpty()) {
-            chartArea.getChildren().add(new Label("Brak danych spełniających kryteria."));
+            setChartPlaceholder("Brak danych spełniających kryteria.");
             return;
         }
 
@@ -261,7 +368,7 @@ public class ReportView {
             for (ReportDataPoint dp : data) {
                 pieChart.getData().add(new PieChart.Data(dp.label(), dp.value().doubleValue()));
             }
-            chartArea.getChildren().add(pieChart);
+            setChartContent(pieChart);
             return;
         }
 
@@ -294,14 +401,12 @@ public class ReportView {
         }
 
         chart.getData().add(series);
-        chartArea.getChildren().add(chart);
+        setChartContent(chart);
     }
 
     private static void updateSeriesChart(List<SeriesReportDataPoint> data) {
-        chartArea.getChildren().clear();
-
         if (data == null || data.isEmpty()) {
-            chartArea.getChildren().add(new Label("Brak danych spełniających kryteria raportu seryjnego."));
+            setChartPlaceholder("Brak danych spełniających kryteria raportu seryjnego.");
             return;
         }
 
@@ -325,7 +430,7 @@ public class ReportView {
         }
 
         chart.getData().addAll(seriesByName.values());
-        chartArea.getChildren().add(chart);
+        setChartContent(chart);
     }
 
     private static void buildDynamicTable(TableView<Map<String, Object>> table, List<Map<String, Object>> data, String emptyMessage) {
@@ -334,6 +439,7 @@ public class ReportView {
 
         if (data == null || data.isEmpty()) {
             table.setPlaceholder(new Label(emptyMessage));
+            updateExportButtonsState();
             return;
         }
 
@@ -355,6 +461,7 @@ public class ReportView {
 
         // Wrzucenie wszystkich wierszy do tabeli
         table.getItems().addAll(data);
+        updateExportButtonsState();
     }
 
     //KLASA POMOCNICZA DLA WYSZUKIWARKI

--- a/frontend/src/main/java/module-info.java
+++ b/frontend/src/main/java/module-info.java
@@ -1,7 +1,9 @@
 module com.example.frontend {
     requires javafx.controls;
     requires javafx.fxml;
+    requires javafx.swing;
     requires java.net.http;
+    requires java.desktop;
     requires com.google.gson;
     requires atlantafx.base;
     requires org.apache.tomcat.embed.core;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add CSV export actions for generated report tables and raw data tables
- add PNG export for the currently rendered report chart
- keep raw-data columns readable by using horizontal scrolling instead of squeezing all columns into the viewport
- extract reusable frontend utilities for CSV writing and chart snapshot saving, plus JavaFX Swing support

## Testing
- UI fix verified by code inspection
- `sh ./backend/mvnw -f ../frontend/pom.xml test` *(fails on this runner because only Java 21 is installed while the frontend Maven config targets Java 23: `invalid target release: 23`)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dae9907-17a5-4047-9fb9-f02b293e8369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dae9907-17a5-4047-9fb9-f02b293e8369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

