### PR TITLE
feat: Zablokowanie dostępu do plików innych użytkowników (Closes #72)

### DIFF
--- a/backend/src/main/java/com/medicalyticsss/backend/controller/FileController.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/controller/FileController.java
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.security.core.Authentication;
+import com.medicalyticsss.backend.model.User;
+import com.medicalyticsss.backend.repository.UserRepository;
 
 import java.io.IOException;
 import java.nio.file.*;
@@ -26,24 +29,34 @@ public class FileController {
     private final FileHistoryRepository fileHistoryRepository;
     private final CsvProcessingService csvProcessingService;
     private final ProcessingErrorRepository processingErrorRepository;
+    private final UserRepository userRepository;
 
-    public FileController(FileHistoryRepository fileHistoryRepository, CsvProcessingService csvProcessingService, ProcessingErrorRepository processingErrorRepository) {
+    public FileController(FileHistoryRepository fileHistoryRepository, CsvProcessingService csvProcessingService, ProcessingErrorRepository processingErrorRepository, UserRepository userRepository) {
         this.fileHistoryRepository = fileHistoryRepository;
         this.csvProcessingService = csvProcessingService;
         this.processingErrorRepository = processingErrorRepository;
+        this.userRepository = userRepository;
     }
 
-    // tu ja Natalia dodalam endpointa
+    // tu ja Natalia dodalam endpointa - a potem ZAKTUALIZOWALAM pod filtrowanie uzytkownika
     @GetMapping
-    public ResponseEntity<Iterable<FileHistory>> getAllFiles() {
-        // Pobiera wszystkie rekordy z bazy. Frontend sam zadba o to, żeby
-        // nie wyświetlać użytkownikowi plików ze statusem DELETED.
-        return ResponseEntity.ok(fileHistoryRepository.findAll());
+    public ResponseEntity<Iterable<FileHistory>> getAllFiles(Authentication authentication) {
+
+        // Zabezpieczenie na wypadek, gdyby ktoś z frontendu próbował pobrać pliki bez logowania
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).build();
+        }
+
+        // 1. Pobieramy login (username) ze Spring Security
+        String username = authentication.getName();
+
+        // 2. Pobieramy z bazy tylko pliki przypisane do tego loginu
+        return ResponseEntity.ok(fileHistoryRepository.findByUser_Username(username));
     }
 
-    // TYLKO WGRYWANIE NA SUCHO
+    // TYLKO WGRYWANIE NA SUCHO - ZAKTUALIZOWANE O USERA
     @PostMapping("/upload")
-    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
+    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file, Authentication authentication) { // <--- DODANY PARAMETR
 
         if (file.isEmpty()) {
             return ResponseEntity.badRequest().body("Błąd: Wybrany plik jest pusty!");
@@ -77,9 +90,24 @@ public class FileController {
             FileHistory history = new FileHistory();
             history.setFileName(finalFileName);
             history.setUploadTime(LocalDateTime.now());
-            history.setStatus(FileStatus.UPLOADED); // Zostaje w statusie UPLOADED
+            history.setStatus(FileStatus.UPLOADED);
             history.setSuccessCount(0);
             history.setErrorCount(0);
+
+            // >>> NOWA LOGIKA: Szukamy zalogowanego użytkownika i przypisujemy go do pliku <<<
+            if (authentication != null && authentication.isAuthenticated()) {
+                String username = authentication.getName();
+                Optional<User> loggedInUser = userRepository.findByUsername(username);
+
+                if (loggedInUser.isPresent()) {
+                    history.setUser(loggedInUser.get()); // Przypisujemy pełny obiekt User do pliku!
+                } else {
+                    return ResponseEntity.status(401).body("Błąd: Nie znaleziono zalogowanego użytkownika w bazie.");
+                }
+            } else {
+                return ResponseEntity.status(401).body("Błąd: Brak autoryzacji do wgrania pliku.");
+            }
+            // >>> KONIEC NOWEJ LOGIKI <<<
 
             fileHistoryRepository.save(history);
 

--- a/backend/src/main/java/com/medicalyticsss/backend/repository/FileHistoryRepository.java
+++ b/backend/src/main/java/com/medicalyticsss/backend/repository/FileHistoryRepository.java
@@ -4,6 +4,9 @@ import com.medicalyticsss.backend.model.FileHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FileHistoryRepository extends JpaRepository<FileHistory, Long> {
+    List<FileHistory> findByUser_Username(String username);
 }


### PR DESCRIPTION
## Opis zmian
Wprowadzenie pełnej izolacji danych użytkowników (multi-tenancy) w module zarządzania plikami. Zmiany uniemożliwiają użytkownikom podgląd i dostęp do plików wgranych przez inne osoby. Każda sesja widzi teraz wyłącznie swoje własne dane.

Zamyka: #72

### Backend
- **FileHistoryRepository**: Dodano metodę `findByUser_Username(String username)`, która pozwala na filtrowanie historii plików bezpośrednio na poziomie bazy danych z wykorzystaniem relacji `@ManyToOne`.
- **FileController (Pobieranie)**: Zmodyfikowano endpoint `GET /api/files`. Zamiast metody `findAll()`, kontroler wyciąga teraz login aktywnego użytkownika z kontekstu Spring Security (`Authentication`) i zwraca przefiltrowaną listę.
- **FileController (Wgrywanie)**: Zaktualizowano endpoint `POST /api/files/upload`. Do konstruktora wstrzyknięto `UserRepository`. Podczas zapisu nowego pliku system identyfikuje zalogowaną osobę, pobiera jej encję z bazy i poprawnie uzupełnia relację (zapobiega to powstawaniu wartości `NULL` w kolumnie `user_id`).

### Frontend (JavaFX)
- Brak konieczności zmian w kodzie klienckim – frontend automatycznie i poprawnie konsumuje przefiltrowane dane dostarczane przez zabezpieczony endpoint backendowy.

## Jak przetestować?
1. Zrestartuj backend i uruchom aplikację JavaFX.
2. Zarejestruj/zaloguj się na nowe konto (np. `user_test_1`) i wgraj plik CSV. Upewnij się, że pojawił się na liście.
3. Wyloguj się / uruchom aplikację ponownie i zaloguj się na drugie konto (np. `user_test_2`). Lista plików powinna być pusta.
4. Wgraj plik jako `user_test_2` – na liście powinien być widoczny tylko ten jeden, nowy plik.
5. Przeloguj się z powrotem na `user_test_1` i zweryfikuj, czy widzisz tylko swój pierwszy plik (brak widoczności pliku użytkownika drugiego).