### PR TITLE
One-click Windows portable package for end users

### DIFF
--- a/.github/workflows/build-windows-package.yml
+++ b/.github/workflows/build-windows-package.yml
@@ -1,0 +1,47 @@
+name: Build Windows Portable Package
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'packaging/windows/**'
+      - 'scripts/build-windows-package.*'
+      - '.github/workflows/build-windows-package.yml'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build portable Windows package
+        shell: pwsh
+        run: ./scripts/build-windows-package.ps1
+
+      - name: Upload portable package
+        uses: actions/upload-artifact@v4
+        with:
+          name: medicalytics-windows-portable
+          path: dist/medicalytics-windows-portable.zip
+          if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/medicalytics-windows-portable.zip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 Medical data analytics platform with a Spring Boot REST API, MariaDB warehouse, and JavaFX desktop client.
 
-## Standalone desktop app
+## Windows one-click package (for end users)
+
+External users on Windows can run the full app without installing Java, Docker, or MariaDB:
+
+1. Download `medicalytics-windows-portable.zip` from [GitHub Releases](https://github.com/Medicaliticsss/medicalyticsss/releases) or from the **Build Windows Portable Package** workflow artifacts.
+2. Extract the zip.
+3. Double-click **`Medicalytics.cmd`**.
+
+First launch prepares a local database (1–2 minutes). Data is stored in `%LOCALAPPDATA%\Medicalytics`.
+
+To build this package yourself:
+
+```bat
+scripts\build-windows-package.bat
+```
+
+Output: `dist\medicalytics-windows-portable.zip`
+
+## Standalone desktop app (API already running)
 
 Build a self-contained desktop application with a bundled Java runtime. No JDK or Maven is required to run it after building.
 

--- a/backend/src/main/resources/application-desktop.properties
+++ b/backend/src/main/resources/application-desktop.properties
@@ -1,0 +1,12 @@
+server.port=8080
+spring.datasource.url=jdbc:mariadb://127.0.0.1:3307/medicalytics
+spring.datasource.username=medicalytics
+spring.datasource.password=medicalytics
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=false
+spring.flyway.enabled=true
+logging.level.org.flywaydb=INFO
+management.endpoints.web.exposure.include=health
+file.upload-dir=${medicalytics.data.dir}/uploads
+dictionary.tests.path=classpath:dictionaries/test-types.json

--- a/packaging/windows/Medicalytics.cmd
+++ b/packaging/windows/Medicalytics.cmd
@@ -1,0 +1,5 @@
+@echo off
+title Medicalytics
+cd /d "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\launch.ps1"
+if errorlevel 1 pause

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -1,0 +1,17 @@
+Medicalytics for Windows
+========================
+
+Requirements:
+  - Windows 10 or newer
+  - No Java, Docker, or database installation needed
+
+How to run:
+  1. Extract this folder anywhere (e.g. Desktop\Medicalytics)
+  2. Double-click Medicalytics.cmd
+  3. Wait for the login window (first launch may take 1-2 minutes)
+
+Data is stored in:
+  %LOCALAPPDATA%\Medicalytics
+
+To stop the app:
+  Close the Medicalytics window. The database and API stop automatically.

--- a/packaging/windows/scripts/launch.ps1
+++ b/packaging/windows/scripts/launch.ps1
@@ -1,0 +1,124 @@
+$ErrorActionPreference = "Stop"
+
+$InstallRoot = Split-Path $PSScriptRoot -Parent
+
+$RuntimeDir = Join-Path $InstallRoot "runtime"
+$DataDir = Join-Path $env:LOCALAPPDATA "Medicalytics"
+$MysqlDataDir = Join-Path $DataDir "mysql"
+$UploadsDir = Join-Path $DataDir "uploads"
+$LogsDir = Join-Path $DataDir "logs"
+$MysqlDir = Join-Path $RuntimeDir "mariadb"
+$BackendJar = Join-Path $RuntimeDir "backend\backend.jar"
+$DesktopExe = Join-Path $RuntimeDir "desktop\Medicalytics.exe"
+$JavaExe = Join-Path $RuntimeDir "jre\bin\java.exe"
+$MysqldExe = Join-Path $MysqlDir "bin\mysqld.exe"
+$MysqlExe = Join-Path $MysqlDir "bin\mysql.exe"
+$MyIni = Join-Path $MysqlDir "my.ini"
+$InitMarker = Join-Path $DataDir "mysql-initialized"
+
+$MysqldProcess = $null
+$BackendProcess = $null
+
+function Stop-Services {
+    if ($BackendProcess -and -not $BackendProcess.HasExited) {
+        Stop-Process -Id $BackendProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+    if ($MysqldProcess -and -not $MysqldProcess.HasExited) {
+        & $MysqlExe --defaults-file="$MyIni" -u root -e "SHUTDOWN;" 2>$null | Out-Null
+        Start-Sleep -Seconds 2
+        if (-not $MysqldProcess.HasExited) {
+            Stop-Process -Id $MysqldProcess.Id -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+trap {
+    Stop-Services
+    [System.Windows.Forms.MessageBox]::Show(
+        "Medicalytics failed to start:`n`n$($_.Exception.Message)",
+        "Medicalytics",
+        [System.Windows.Forms.MessageBoxButtons]::OK,
+        [System.Windows.Forms.MessageBoxIcon]::Error
+    ) | Out-Null
+    exit 1
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+
+foreach ($path in @($DataDir, $MysqlDataDir, $UploadsDir, $LogsDir)) {
+    New-Item -ItemType Directory -Force -Path $path | Out-Null
+}
+
+if (-not (Test-Path $DesktopExe)) { throw "Desktop app not found: $DesktopExe" }
+if (-not (Test-Path $BackendJar)) { throw "Backend not found: $BackendJar" }
+if (-not (Test-Path $MysqldExe)) { throw "MariaDB not found: $MysqldExe" }
+
+$iniContent = @"
+[mysqld]
+port=3307
+bind-address=127.0.0.1
+datadir=$($MysqlDataDir.Replace('\', '/'))
+max_allowed_packet=64M
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+console
+
+[client]
+port=3307
+"@
+Set-Content -Path $MyIni -Value $iniContent -Encoding ASCII
+
+if (-not (Test-Path $InitMarker)) {
+    Write-Host "First launch: preparing local database (this may take a minute)..."
+    & $MysqldExe --defaults-file="$MyIni" --initialize-insecure | Out-Null
+
+    $MysqldProcess = Start-Process -FilePath $MysqldExe -ArgumentList @("--defaults-file=$MyIni") -WindowStyle Hidden -PassThru
+    Start-Sleep -Seconds 10
+
+    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e "CREATE DATABASE IF NOT EXISTS medicalytics;" | Out-Null
+    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e "CREATE USER IF NOT EXISTS 'medicalytics'@'localhost' IDENTIFIED BY 'medicalytics';" | Out-Null
+    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e "GRANT ALL PRIVILEGES ON medicalytics.* TO 'medicalytics'@'localhost'; FLUSH PRIVILEGES;" | Out-Null
+    New-Item -ItemType File -Force -Path $InitMarker | Out-Null
+    Stop-Services
+    $MysqldProcess = $null
+}
+
+Write-Host "Starting database and API..."
+$MysqldProcess = Start-Process -FilePath $MysqldExe -ArgumentList @("--defaults-file=$MyIni") -WindowStyle Hidden -PassThru
+Start-Sleep -Seconds 4
+
+$backendArgs = @(
+    "-jar", $BackendJar,
+    "--spring.profiles.active=desktop",
+    "-Dmedicalytics.data.dir=$DataDir"
+)
+$BackendProcess = Start-Process -FilePath $JavaExe -ArgumentList $backendArgs -WindowStyle Hidden -PassThru -WorkingDirectory (Split-Path $BackendJar -Parent)
+
+Write-Host "Waiting for API..."
+$healthy = $false
+for ($i = 0; $i -lt 90; $i++) {
+    try {
+        $response = Invoke-WebRequest -Uri "http://127.0.0.1:8080/actuator/health" -UseBasicParsing -TimeoutSec 2
+        if ($response.StatusCode -eq 200) {
+            $healthy = $true
+            break
+        }
+    } catch {
+        if ($BackendProcess.HasExited) {
+            throw "Backend stopped unexpectedly. Check logs in $LogsDir"
+        }
+        Start-Sleep -Seconds 2
+    }
+}
+
+if (-not $healthy) {
+    throw "API did not become ready in time."
+}
+
+Write-Host "Launching Medicalytics..."
+$env:MEDICALYTICS_API_URL = "http://127.0.0.1:8080"
+$DesktopProcess = Start-Process -FilePath $DesktopExe -PassThru
+Wait-Process -Id $DesktopProcess.Id
+
+Write-Host "Shutting down..."
+Stop-Services

--- a/scripts/build-windows-package.bat
+++ b/scripts/build-windows-package.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+cd /d "%~dp0.."
+
+call "%~dp0setup-jdk.bat"
+if errorlevel 1 exit /b 1
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build-windows-package.ps1"
+exit /b %ERRORLEVEL%

--- a/scripts/build-windows-package.ps1
+++ b/scripts/build-windows-package.ps1
@@ -1,0 +1,75 @@
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path $PSScriptRoot -Parent
+$FrontendDir = Join-Path $RootDir "frontend"
+$BackendDir = Join-Path $RootDir "backend"
+$PackagingDir = Join-Path $RootDir "packaging\windows"
+$DistDir = Join-Path $RootDir "dist\Medicalytics-Windows"
+$RuntimeDir = Join-Path $DistDir "runtime"
+$CacheDir = Join-Path $RootDir "dist\cache"
+$Mvnw = Join-Path $BackendDir "mvnw.cmd"
+
+$MariaDbVersion = "11.4.5"
+$MariaDbZip = "mariadb-$MariaDbVersion-winx64.zip"
+$MariaDbUrl = "https://archive.mariadb.org/mariadb-$MariaDbVersion/winx64-packages/$MariaDbZip"
+$JreZip = "temurin-jre-17-windows-x64.zip"
+$JreUrl = "https://api.adoptium.net/v3/binary/latest/17/ga/windows/x64/jre/hotspot/normal/eclipse?project=jdk"
+
+function Ensure-Download($Url, $Destination) {
+    if (-not (Test-Path $Destination)) {
+        New-Item -ItemType Directory -Force -Path (Split-Path $Destination -Parent) | Out-Null
+        Write-Host "Downloading $Url"
+        Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
+    }
+}
+
+Write-Host "Building backend..."
+Push-Location $BackendDir
+& $Mvnw -B -DskipTests clean package
+if ($LASTEXITCODE -ne 0) { throw "Backend build failed." }
+Pop-Location
+
+Write-Host "Building desktop app..."
+Push-Location $FrontendDir
+& $Mvnw -f pom.xml -B -DskipTests clean package
+if ($LASTEXITCODE -ne 0) { throw "Desktop build failed." }
+Pop-Location
+
+$BackendJar = Get-ChildItem (Join-Path $BackendDir "target\backend-*.jar") | Where-Object { $_.Name -notmatch "original" } | Select-Object -First 1
+$DesktopImage = Join-Path $FrontendDir "target\dist\Medicalytics"
+if (-not (Test-Path $DesktopImage)) { throw "Desktop image not found at $DesktopImage" }
+
+if (Test-Path $DistDir) { Remove-Item $DistDir -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $RuntimeDir | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $RuntimeDir "backend") | Out-Null
+
+Ensure-Download $MariaDbUrl (Join-Path $CacheDir $MariaDbZip)
+Ensure-Download $JreUrl (Join-Path $CacheDir $JreZip)
+
+Write-Host "Unpacking runtime dependencies..."
+Expand-Archive -Path (Join-Path $CacheDir $MariaDbZip) -DestinationPath (Join-Path $CacheDir "mariadb-extract") -Force
+$MariaDbExtracted = Get-ChildItem (Join-Path $CacheDir "mariadb-extract") | Where-Object { $_.PSIsContainer } | Select-Object -First 1
+Copy-Item -Path $MariaDbExtracted.FullName -Destination (Join-Path $RuntimeDir "mariadb") -Recurse
+
+Expand-Archive -Path (Join-Path $CacheDir $JreZip) -DestinationPath (Join-Path $CacheDir "jre-extract") -Force
+$JreExtracted = Get-ChildItem (Join-Path $CacheDir "jre-extract") | Where-Object { $_.PSIsContainer } | Select-Object -First 1
+Copy-Item -Path $JreExtracted.FullName -Destination (Join-Path $RuntimeDir "jre") -Recurse
+
+Copy-Item $BackendJar.FullName (Join-Path $RuntimeDir "backend\backend.jar")
+Copy-Item $DesktopImage (Join-Path $RuntimeDir "desktop") -Recurse
+
+Copy-Item (Join-Path $PackagingDir "Medicalytics.cmd") $DistDir
+Copy-Item (Join-Path $PackagingDir "README.txt") $DistDir
+New-Item -ItemType Directory -Force -Path (Join-Path $DistDir "scripts") | Out-Null
+Copy-Item (Join-Path $PackagingDir "scripts\launch.ps1") (Join-Path $DistDir "scripts\launch.ps1")
+
+$Archive = Join-Path $RootDir "dist\medicalytics-windows-portable.zip"
+if (Test-Path $Archive) { Remove-Item $Archive -Force }
+Compress-Archive -Path $DistDir -DestinationPath $Archive
+
+Write-Host ""
+Write-Host "Windows portable package ready:"
+Write-Host "  Folder:  $DistDir"
+Write-Host "  Archive: $Archive"
+Write-Host ""
+Write-Host "For end users: extract the zip and double-click Medicalytics.cmd"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **single downloadable Windows package** that external users can run without installing Java, Docker, or MariaDB.

## End-user experience

1. Download `medicalytics-windows-portable.zip`
2. Extract it
3. Double-click **`Medicalytics.cmd`**

The launcher automatically:
- Starts bundled MariaDB (first launch initializes a local database)
- Starts the Spring Boot API
- Opens the desktop app
- Stops background services when the user closes the app

User data is stored in `%LOCALAPPDATA%\Medicalytics`.

## What's included in the package

| Component | Purpose |
|-----------|---------|
| Portable MariaDB 11.4 | Local database on port 3307 |
| Temurin JRE 17 | Runs the backend |
| Backend JAR (`desktop` profile) | API on port 8080 |
| Desktop app (jpackage) | JavaFX UI with bundled runtime |

## How to build

```bat
scripts\build-windows-package.bat
```

Output: `dist\medicalytics-windows-portable.zip`

## CI

New workflow **Build Windows Portable Package** builds the zip on `windows-latest` and uploads it as an artifact. When attached to a GitHub Release, the zip is published automatically.

## Notes

- Docker is no longer required for Windows end users
- Developers can still use Docker / `javafx:run` as before
- First launch may take 1–2 minutes while the database is initialized
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

