### PR TITLE
Auto-publish Windows portable zip to GitHub Releases

### DIFF
--- a/.github/workflows/build-windows-package.yml
+++ b/.github/workflows/build-windows-package.yml
@@ -7,8 +7,6 @@ on:
       - main
     tags:
       - 'v*'
-  release:
-    types: [published]
 
 permissions:
   contents: write
@@ -63,12 +61,35 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-      - name: Attach to GitHub Release
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+      - name: Publish to GitHub Releases (latest Windows build)
+        if: github.ref == 'refs/heads/main'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          tag: windows-portable-latest
+          name: Medicalytics for Windows
+          body: |
+            ## Download and run
+
+            1. Download **medicalytics-windows-portable.zip** below
+            2. Extract the folder
+            3. Double-click **Medicalytics.cmd**
+            4. Wait 1–2 minutes on first launch (database setup)
+
+            No Java, Docker, or MariaDB installation required.
+
+            **Direct link:** https://github.com/${{ github.repository }}/releases/latest/download/medicalytics-windows-portable.zip
+
+            Built from `${{ github.sha }}` (workflow run ${{ github.run_number }}).
+          artifacts: dist/medicalytics-windows-portable.zip
+          makeLatest: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish versioned release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: dist/medicalytics-windows-portable.zip
-          draft: ${{ github.event_name != 'release' }}
           generate_release_notes: true
 
       - name: Build summary
@@ -78,14 +99,14 @@ jobs:
           @"
           ## Windows portable package
 
-          - **Artifact:** medicalytics-windows-portable
           - **File:** medicalytics-windows-portable.zip ($sizeMb MB)
           - **Run:** ${{ github.run_number }}
 
-          ### Download
+          ### Download for end users
 
-          1. Open this workflow run on GitHub
-          2. Scroll to **Artifacts**
-          3. Download **medicalytics-windows-portable**
-          4. Extract and double-click **Medicalytics.cmd**
+          **[GitHub Releases (recommended)](https://github.com/${{ github.repository }}/releases/latest)**
+
+          Direct download: https://github.com/${{ github.repository }}/releases/latest/download/medicalytics-windows-portable.zip
+
+          Extract the zip and double-click **Medicalytics.cmd**.
           "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8

--- a/README.md
+++ b/README.md
@@ -2,32 +2,21 @@
 
 Medical data analytics platform with a Spring Boot REST API, MariaDB warehouse, and JavaFX desktop client.
 
-## Windows portable package (one-click)
+## Download for Windows
 
-No Java, Docker, or MariaDB installation required.
+**[Download Medicalytics for Windows (latest release)](https://github.com/Medicaliticsss/medicalyticsss/releases/latest)**
 
-1. Extract the zip
+Direct link: [medicalytics-windows-portable.zip](https://github.com/Medicaliticsss/medicalyticsss/releases/latest/download/medicalytics-windows-portable.zip)
+
+### How to run
+
+1. Download and extract the zip
 2. Double-click **`Medicalytics.cmd`**
-3. Wait 1–2 minutes on first launch
+3. Wait 1–2 minutes on first launch (database setup)
 
-Data is stored in `%LOCALAPPDATA%\Medicalytics`.
+No Java, Docker, or MariaDB installation required. Data is stored in `%LOCALAPPDATA%\Medicalytics`.
 
-### Download from GitHub Actions
-
-1. Open **Actions** → **Build Windows Portable Package**
-2. Click **Run workflow** → branch `main` → **Run workflow**
-3. When the run finishes, download artifact **medicalytics-windows-portable**
-4. Extract and run **`Medicalytics.cmd`**
-
-Artifacts are kept for 90 days. Pushes to `main` and tags `v*` also trigger builds automatically.
-
-### Build locally
-
-```bat
-scripts\build-windows-package.bat
-```
-
-Output: `dist\medicalytics-windows-portable.zip`
+> The Windows package is built automatically on every push to `main` and published under [Releases](https://github.com/Medicaliticsss/medicalyticsss/releases).
 
 ## Development
 
@@ -37,3 +26,11 @@ See [docs/README.md](docs/README.md) for manual setup. Docker quick start:
 docker compose up -d --build
 cd frontend && ../backend/mvnw -Pdev javafx:run
 ```
+
+### Build the Windows package locally
+
+```bat
+scripts\build-windows-package.bat
+```
+
+Output: `dist\medicalytics-windows-portable.zip`

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -5,6 +5,9 @@ Requirements:
   - Windows 10 or newer
   - No Java, Docker, or database installation needed
 
+Download:
+  https://github.com/Medicaliticsss/medicalyticsss/releases/latest
+
 How to run:
   1. Extract this folder anywhere (e.g. Desktop\Medicalytics)
   2. Double-click Medicalytics.cmd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publishes `medicalytics-windows-portable.zip` to **GitHub Releases** automatically so normal users don't need to dig through Actions artifacts.

## End-user download

After merge, users can go to:

**https://github.com/Medicaliticsss/medicalyticsss/releases/latest**

Or use the direct link:

**https://github.com/Medicaliticsss/medicalyticsss/releases/latest/download/medicalytics-windows-portable.zip**

## How it works

- Every push to `main` builds the zip and **updates** the `windows-portable-latest` release
- The release is marked as **Latest** on GitHub
- Tags `v*` still create separate versioned releases
- Actions artifacts remain available for developers

## README

Updated with a prominent **Download for Windows** section at the top.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

