### PR TITLE
Fix Windows portable API startup after database init

### DIFF
--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -19,7 +19,8 @@ Data is stored in:
 To stop the app:
   Close the Medicalytics window. The database and API stop automatically.
 
-If first launch fails with a database error:
+If startup fails:
   1. Close Medicalytics
-  2. Delete folder: %LOCALAPPDATA%\Medicalytics
-  3. Start Medicalytics.cmd again
+  2. Check logs in: %LOCALAPPDATA%\Medicalytics\logs
+  3. For database errors, delete folder: %LOCALAPPDATA%\Medicalytics
+  4. Start Medicalytics.cmd again

--- a/packaging/windows/scripts/launch.ps1
+++ b/packaging/windows/scripts/launch.ps1
@@ -33,6 +33,26 @@ function Reset-MysqlDataDir {
     New-Item -ItemType Directory -Force -Path $DataDir | Out-Null
 }
 
+function Ensure-DatabaseUsers {
+    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e @"
+CREATE DATABASE IF NOT EXISTS medicalytics;
+CREATE USER IF NOT EXISTS 'medicalytics'@'localhost' IDENTIFIED BY 'medicalytics';
+CREATE USER IF NOT EXISTS 'medicalytics'@'127.0.0.1' IDENTIFIED BY 'medicalytics';
+GRANT ALL PRIVILEGES ON medicalytics.* TO 'medicalytics'@'localhost';
+GRANT ALL PRIVILEGES ON medicalytics.* TO 'medicalytics'@'127.0.0.1';
+FLUSH PRIVILEGES;
+"@ | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not configure database users for the API."
+    }
+}
+
+function Get-BackendLogTail {
+    param([string]$LogPath, [int]$Lines = 20)
+    if (-not (Test-Path $LogPath)) { return "(no backend log written)" }
+    return (Get-Content $LogPath -Tail $Lines -ErrorAction SilentlyContinue) -join "`n"
+}
+
 $MysqldProcess = $null
 $BackendProcess = $null
 
@@ -110,14 +130,7 @@ if (-not (Test-Path $InitMarker)) {
     $MysqldProcess = Start-Process -FilePath $MysqldExe -ArgumentList @("--defaults-file=$MyIni") -WindowStyle Hidden -PassThru
     Start-Sleep -Seconds 10
 
-    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e "CREATE DATABASE IF NOT EXISTS medicalytics;"
-    if ($LASTEXITCODE -ne 0) { throw "Could not create medicalytics database." }
-
-    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e "CREATE USER IF NOT EXISTS 'medicalytics'@'localhost' IDENTIFIED BY 'medicalytics';"
-    if ($LASTEXITCODE -ne 0) { throw "Could not create medicalytics database user." }
-
-    & $MysqlExe --defaults-file="$MyIni" -u root --protocol=tcp -e "GRANT ALL PRIVILEGES ON medicalytics.* TO 'medicalytics'@'localhost'; FLUSH PRIVILEGES;"
-    if ($LASTEXITCODE -ne 0) { throw "Could not grant database privileges." }
+    Ensure-DatabaseUsers
 
     New-Item -ItemType File -Force -Path $InitMarker | Out-Null
     Stop-Services
@@ -126,34 +139,55 @@ if (-not (Test-Path $InitMarker)) {
 
 Write-Host "Starting database and API..."
 $MysqldProcess = Start-Process -FilePath $MysqldExe -ArgumentList @("--defaults-file=$MyIni") -WindowStyle Hidden -PassThru
-Start-Sleep -Seconds 4
+Start-Sleep -Seconds 6
 
+Ensure-DatabaseUsers
+
+$DataDirForJvm = $DataDir.Replace('\', '/')
+$BackendLog = Join-Path $LogsDir "backend.log"
+$BackendErrorLog = Join-Path $LogsDir "backend-error.log"
+if (Test-Path $BackendLog) { Remove-Item $BackendLog -Force }
+if (Test-Path $BackendErrorLog) { Remove-Item $BackendErrorLog -Force }
+
+# JVM -D options must appear before -jar, otherwise Java ignores them.
 $backendArgs = @(
+    "-Dmedicalytics.data.dir=$DataDirForJvm",
     "-jar", $BackendJar,
     "--spring.profiles.active=desktop",
-    "-Dmedicalytics.data.dir=$DataDir"
+    "--medicalytics.data.dir=$DataDirForJvm"
 )
-$BackendProcess = Start-Process -FilePath $JavaExe -ArgumentList $backendArgs -WindowStyle Hidden -PassThru -WorkingDirectory (Split-Path $BackendJar -Parent)
+$BackendProcess = Start-Process -FilePath $JavaExe -ArgumentList $backendArgs -WindowStyle Hidden -PassThru `
+    -WorkingDirectory (Split-Path $BackendJar -Parent) `
+    -RedirectStandardOutput $BackendLog -RedirectStandardError $BackendErrorLog
 
 Write-Host "Waiting for API..."
 $healthy = $false
 for ($i = 0; $i -lt 90; $i++) {
+    if ($BackendProcess.HasExited) {
+        $logTail = Get-BackendLogTail $BackendErrorLog
+        if ($logTail -eq "(no backend log written)") {
+            $logTail = Get-BackendLogTail $BackendLog
+        }
+        throw "Backend stopped unexpectedly.`n`nLog tail:`n$logTail"
+    }
+
     try {
         $response = Invoke-WebRequest -Uri "http://127.0.0.1:8080/actuator/health" -UseBasicParsing -TimeoutSec 2
-        if ($response.StatusCode -eq 200) {
+        if ($response.StatusCode -eq 200 -and $response.Content -match '"status"\s*:\s*"UP"') {
             $healthy = $true
             break
         }
     } catch {
-        if ($BackendProcess.HasExited) {
-            throw "Backend stopped unexpectedly. Check logs in $LogsDir"
-        }
         Start-Sleep -Seconds 2
     }
 }
 
 if (-not $healthy) {
-    throw "API did not become ready in time."
+    $logTail = Get-BackendLogTail $BackendErrorLog
+    if ($logTail -eq "(no backend log written)") {
+        $logTail = Get-BackendLogTail $BackendLog
+    }
+    throw "API did not become ready in time.`n`nLog tail:`n$logTail`n`nFull log: $BackendLog"
 }
 
 Write-Host "Launching Medicalytics..."


### PR DESCRIPTION
## Problem

After the MariaDB init fix, the database starts but the launcher hangs on **Waiting for API...** and then fails.

Two root causes:

1. **JVM property order** — `-Dmedicalytics.data.dir=...` was passed *after* `-jar`, so Java ignored it. Spring could not resolve `file.upload-dir` and the backend failed to start.
2. **DB user host mismatch** — user was created as `medicalytics@localhost`, but the JDBC URL connects via TCP to `127.0.0.1`. MariaDB treats these as different accounts, so authentication failed and `/actuator/health` stayed DOWN.

## Fix

- Pass `-Dmedicalytics.data.dir` before `-jar`, with forward-slash paths
- Create/grant `medicalytics@127.0.0.1` in addition to `medicalytics@localhost`
- Re-run DB user setup on every launch (fixes installs that already initialized)
- Write backend logs to `%LOCALAPPDATA%\Medicalytics\logs`

## For users already affected

No need to wipe the database — update `launch.ps1` or download a new release zip after merge. Existing `%LOCALAPPDATA%\Medicalytics` data is kept.
