### PR TITLE
Fix false MariaDB not ready when server is already listening

### DIFF
--- a/packaging/windows/scripts/launch.ps1
+++ b/packaging/windows/scripts/launch.ps1
@@ -86,6 +86,7 @@ function Invoke-MysqlTcp {
     $args = @(
         "--defaults-file=$MyIni",
         "--protocol=tcp",
+        "--skip-ssl",
         "-h", $HostName,
         "-P", "3307",
         "-u", $User,
@@ -96,7 +97,7 @@ function Invoke-MysqlTcp {
     }
 
     $output = & $MysqlExe @args 2>&1
-    if (-not $?) {
+    if ($LASTEXITCODE -ne 0) {
         $details = ($output | Out-String).Trim()
         if ($details) {
             throw "MariaDB command failed: $details`n`n$(Get-MariaDbErrorTail)"
@@ -107,7 +108,16 @@ function Invoke-MysqlTcp {
 
 function Invoke-MysqlAdmin {
     param([string]$Sql)
-    Invoke-MysqlTcp -Sql $Sql -User "root" -HostName "localhost"
+    $lastError = $null
+    foreach ($hostName in @("127.0.0.1", "localhost")) {
+        try {
+            Invoke-MysqlTcp -Sql $Sql -User "root" -HostName $hostName
+            return
+        } catch {
+            $lastError = $_
+        }
+    }
+    throw $lastError
 }
 
 function Ensure-DatabaseUsers {
@@ -129,6 +139,18 @@ function Start-MariaDbServer {
         -WorkingDirectory $MysqlDir
 }
 
+function Test-MariaDbPortOpen {
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $client.Connect("127.0.0.1", 3307)
+        $open = $client.Connected
+        $client.Close()
+        return $open
+    } catch {
+        return $false
+    }
+}
+
 function Wait-MariaDbReady {
     Write-Host "Waiting for database..."
     for ($i = 0; $i -lt 45; $i++) {
@@ -136,12 +158,11 @@ function Wait-MariaDbReady {
             throw "MariaDB stopped during startup.`n`n$(Get-MariaDbErrorTail)"
         }
 
-        try {
-            Invoke-MysqlTcp -Sql "SELECT 1" -User "root" -HostName "localhost" | Out-Null
+        if (Test-MariaDbPortOpen) {
             return
-        } catch {
-            Start-Sleep -Seconds 2
         }
+
+        Start-Sleep -Seconds 2
     }
     throw "MariaDB did not become ready.`n`n$(Get-MariaDbErrorTail)"
 }
@@ -216,7 +237,8 @@ if (-not (Test-Path $InitMarker)) {
 
     $installProcess = Start-Process -FilePath $MysqlInstallDbExe -ArgumentList @(
         "--datadir=$MysqlDataDir",
-        "-P", "3307"
+        "-P", "3307",
+        "-R"
     ) -Wait -PassThru -NoNewWindow -WorkingDirectory $MysqlDir
     if ($installProcess.ExitCode -ne 0) {
         throw "Database initialization failed (exit $($installProcess.ExitCode)). Delete `"$DataDir`" and try again."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

MariaDB log shows the server is ready:

```
ready for connections. Version: '11.4.5-MariaDB' ... port: 3307
```

But the launcher still fails with **MariaDB did not become ready**.

Root causes:
1. `Wait-MariaDbReady` required a successful `root` login instead of checking whether port 3307 is open
2. PowerShell treated mysql SSL warnings as command failures (`$?` false even when exit code was 0)
3. `root@localhost` often cannot authenticate over TCP on Windows after `mysql_install_db`

## Fix

- Wait for TCP port `127.0.0.1:3307` to accept connections
- Use `$LASTEXITCODE` instead of `$?` for mysql commands
- Pass `-R` to `mysql_install_db` to allow local root TCP access
- Add `--skip-ssl` to client commands
- Try both `127.0.0.1` and `localhost` for admin SQL

## User action

Merge, download fresh release zip, delete `%LOCALAPPDATA%\\Medicalytics`, run `Medicalytics.cmd`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

