### PR TITLE
Fix Windows desktop app launch blocked by Mark of the Web

### DIFF
--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -26,3 +26,8 @@ If startup fails:
      - mariadb-error.log (database)
   3. For database errors, delete folder: %LOCALAPPDATA%\Medicalytics
   4. Download the latest zip and start Medicalytics.cmd again
+
+If Windows blocks the app ("operation was cancelled by the user"):
+  1. Right-click the extracted Medicalytics-Windows folder
+  2. Properties -> Unblock -> Apply
+  3. Run Medicalytics.cmd again

--- a/packaging/windows/scripts/launch.ps1
+++ b/packaging/windows/scripts/launch.ps1
@@ -243,6 +243,33 @@ function Get-BackendLogTail {
     return "(no backend log written yet)"
 }
 
+function Unblock-PortableAppFiles {
+    foreach ($path in @($InstallRoot, $DataDir)) {
+        if (-not (Test-Path $path)) { continue }
+        Get-ChildItem -Path $path -Recurse -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue
+    }
+}
+
+function Start-DesktopApp {
+    $DesktopDir = Split-Path $DesktopExe -Parent
+    Unblock-PortableAppFiles
+
+    $env:MEDICALYTICS_API_URL = "http://127.0.0.1:8080"
+
+    try {
+        return Start-Process -FilePath $DesktopExe -WorkingDirectory $DesktopDir -PassThru -ErrorAction Stop
+    } catch {
+        throw @"
+Failed to start desktop app: $($_.Exception.Message)
+
+If you downloaded the zip from the internet, Windows may be blocking it.
+Right-click the extracted folder -> Properties -> check 'Unblock' -> Apply, then try again.
+
+Desktop app: $DesktopExe
+"@
+    }
+}
+
 $MysqldProcess = $null
 $BackendProcess = $null
 
@@ -279,6 +306,7 @@ if (-not (Test-Path $MysqldExe)) { throw "MariaDB not found: $MysqldExe" }
 if (-not (Test-Path $MysqlInstallDbExe)) { throw "MariaDB installer not found: $MysqlInstallDbExe" }
 
 Write-MyIni
+Unblock-PortableAppFiles
 
 if (-not (Test-Path $InitMarker)) {
     Write-Host "First launch: preparing local database (this may take a minute)..."
@@ -336,8 +364,7 @@ $BackendProcess = Start-Process -FilePath $JavaExe -ArgumentList $backendArgs -W
 Wait-ForApi
 
 Write-Host "Launching Medicalytics..."
-$env:MEDICALYTICS_API_URL = "http://127.0.0.1:8080"
-$DesktopProcess = Start-Process -FilePath $DesktopExe -PassThru
+$DesktopProcess = Start-DesktopApp
 Wait-Process -Id $DesktopProcess.Id
 
 Write-Host "Shutting down..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Startup now reaches:

```
API port is open and backend is running.
Launching Medicalytics...
```

Then fails with Polish Windows error:

```
Operacja została anulowana przez użytkownika
(The operation was cancelled by the user)
```

This usually means Windows blocked `Medicalytics.exe` from a downloaded zip (Mark of the Web / SmartScreen), or the app was started without its working directory.

## Fix

- `Unblock-File` recursively on the portable install folder before startup
- Launch `Medicalytics.exe` with `-WorkingDirectory` set to the desktop app folder
- Clear error message with manual unblock instructions

## User workaround now

Right-click extracted folder -> Properties -> Unblock -> Apply -> run `Medicalytics.cmd` again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

