### PR TITLE
Fix Windows launch after session feature merge

### DIFF
--- a/frontend/src/main/java/com/example/frontend/views/LoginView.java
+++ b/frontend/src/main/java/com/example/frontend/views/LoginView.java
@@ -26,13 +26,11 @@ public class LoginView {
         titleLabel.setStyle("-fx-text-fill: #FF0055;");
 
         ImageView logoView = new ImageView();
-        try {
-            Image logoImage = new Image(LoginView.class.getResourceAsStream("/images/przezroczyste.png"));
-            logoView.setImage(logoImage);
+        var logoUrl = LoginView.class.getResource("/images/przezroczyste.png");
+        if (logoUrl != null) {
+            logoView.setImage(new Image(logoUrl.toExternalForm()));
             logoView.setFitWidth(350);
             logoView.setPreserveRatio(true);
-        } catch (Exception e) {
-            System.err.println("Błąd ładowania logo: " + e.getMessage());
         }
         Label screenTitle = new Label("Logowanie");
         screenTitle.getStyleClass().add(Styles.TITLE_3);
@@ -57,8 +55,6 @@ public class LoginView {
             AuthService.login(usernameInput.getText(), passwordInput.getText()).thenAccept(res -> {
                 Platform.runLater(() -> {
                     if (res.equals("SUCCESS")) {
-                        UserSession.getInstance().startSession(usernameInput.getText());
-
                         ViewManager.switchView(MainMenuView.getView());
                     } else {
                         errorLabel.setText(res);

--- a/frontend/src/main/java/com/example/frontend/views/MainMenuView.java
+++ b/frontend/src/main/java/com/example/frontend/views/MainMenuView.java
@@ -22,13 +22,11 @@ public class MainMenuView {
         root.setPadding(new Insets(40));
 
         ImageView logoView = new ImageView();
-        try {
-            Image logoImage = new Image(MainMenuView.class.getResourceAsStream("/images/przezroczyste.png"));
-            logoView.setImage(logoImage);
+        var logoUrl = MainMenuView.class.getResource("/images/przezroczyste.png");
+        if (logoUrl != null) {
+            logoView.setImage(new Image(logoUrl.toExternalForm()));
             logoView.setFitHeight(500);
             logoView.setPreserveRatio(true);
-        } catch (Exception e) {
-            System.err.println("Błąd ładowania logo: " + e.getMessage());
         }
         Button logoutBtn = new Button("Wyloguj");
         logoutBtn.getStyleClass().addAll(Styles.BUTTON_OUTLINED, Styles.DANGER);

--- a/frontend/src/main/java/com/example/frontend/views/RegisterView.java
+++ b/frontend/src/main/java/com/example/frontend/views/RegisterView.java
@@ -19,13 +19,11 @@ public class RegisterView {
         layout.setAlignment(Pos.CENTER);
 
         ImageView logoView = new ImageView();
-        try {
-            Image logoImage = new Image(RegisterView.class.getResourceAsStream("/images/przezroczyste.png"));
-            logoView.setImage(logoImage);
+        var logoUrl = RegisterView.class.getResource("/images/przezroczyste.png");
+        if (logoUrl != null) {
+            logoView.setImage(new Image(logoUrl.toExternalForm()));
             logoView.setFitWidth(300);
             logoView.setPreserveRatio(true);
-        } catch (Exception e) {
-            System.err.println("Błąd ładowania logo: " + e.getMessage());
         }
         Label titleLabel = new Label("Rejestracja");
         titleLabel.getStyleClass().add(Styles.TITLE_3);

--- a/packaging/windows/Medicalytics.cmd
+++ b/packaging/windows/Medicalytics.cmd
@@ -1,5 +1,6 @@
 @echo off
 title Medicalytics
 cd /d "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -LiteralPath '%~dp0' -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object { Unblock-File -LiteralPath $_.FullName -ErrorAction SilentlyContinue; $zone = $_.FullName + ':Zone.Identifier'; if (Test-Path -LiteralPath $zone) { Remove-Item -LiteralPath $zone -Force -ErrorAction SilentlyContinue } }"
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\launch.ps1"
 if errorlevel 1 pause

--- a/packaging/windows/scripts/launch.ps1
+++ b/packaging/windows/scripts/launch.ps1
@@ -243,21 +243,51 @@ function Get-BackendLogTail {
     return "(no backend log written yet)"
 }
 
+function Clear-FileMotw {
+    param([string]$FilePath)
+    if (-not (Test-Path -LiteralPath $FilePath)) { return }
+    Unblock-File -LiteralPath $FilePath -ErrorAction SilentlyContinue
+    $zonePath = "${FilePath}:Zone.Identifier"
+    if (Test-Path -LiteralPath $zonePath) {
+        Remove-Item -LiteralPath $zonePath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Unblock-PortableAppFiles {
     foreach ($path in @($InstallRoot, $DataDir)) {
         if (-not (Test-Path $path)) { continue }
-        Get-ChildItem -Path $path -Recurse -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $path -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+            Clear-FileMotw $_.FullName
+        }
+    }
+}
+
+function Unblock-RuntimeExecutables {
+    foreach ($exe in @($JavaExe, $MysqldExe, $MysqlExe, $MysqlInstallDbExe, $DesktopExe)) {
+        Clear-FileMotw $exe
     }
 }
 
 function Start-DesktopApp {
     $DesktopDir = Split-Path $DesktopExe -Parent
     Unblock-PortableAppFiles
+    Unblock-RuntimeExecutables
+
+    if (Test-Path $DesktopDir) {
+        Get-ChildItem -Path $DesktopDir -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+            Clear-FileMotw $_.FullName
+        }
+    }
 
     $env:MEDICALYTICS_API_URL = "http://127.0.0.1:8080"
 
     try {
-        return Start-Process -FilePath $DesktopExe -WorkingDirectory $DesktopDir -PassThru -ErrorAction Stop
+        $process = Start-Process -FilePath $DesktopExe -WorkingDirectory $DesktopDir -PassThru -ErrorAction Stop
+        Start-Sleep -Milliseconds 750
+        if ($process.HasExited) {
+            throw "Desktop app exited immediately (exit code $($process.ExitCode))."
+        }
+        return $process
     } catch {
         throw @"
 Failed to start desktop app: $($_.Exception.Message)
@@ -307,6 +337,7 @@ if (-not (Test-Path $MysqlInstallDbExe)) { throw "MariaDB installer not found: $
 
 Write-MyIni
 Unblock-PortableAppFiles
+Unblock-RuntimeExecutables
 
 if (-not (Test-Path $InitMarker)) {
     Write-Host "First launch: preparing local database (this may take a minute)..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #95 fixed the Windows portable launch (Mark of the Web / SmartScreen blocking), the session feature merge introduced a new frontend build. Downloading and extracting the updated zip can leave Windows blocking the rebuilt `Medicalytics.exe` and its runtime files again.

## Solution

Applies the same approach as PR #95, but more thoroughly:

- **Medicalytics.cmd** — unblocks all extracted files (and removes `Zone.Identifier` streams) before running the launcher script
- **launch.ps1** — clears MOTW from runtime executables (`java.exe`, `mysqld.exe`, `Medicalytics.exe`, etc.) and the full desktop app folder; detects if the desktop app exits immediately after SmartScreen blocks it
- **Frontend** — safer logo image loading via `getResource()` URL (works reliably in jpackage builds); removed duplicate `startSession()` call in `LoginView`

## How to test

1. Merge this PR and wait for the Windows portable CI build to finish
2. Delete `%LOCALAPPDATA%\Medicalytics` if testing a clean first launch
3. Download the latest `medicalytics-windows-portable.zip` from Releases
4. Extract and run `Medicalytics.cmd`
5. Confirm the login window appears (first launch may take 1–2 minutes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33070cfb-ef3d-400a-bb1f-6182d1313375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

